### PR TITLE
OCPP: add visual user feedback

### DIFF
--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -64,6 +64,10 @@
 #define ENABLE_OCPP 0
 #endif
 
+#if ENABLE_OCPP
+#include <MicroOcpp/Model/ConnectorBase/Notification.h>
+#endif
+
 #ifndef MODEM
 //the wifi-debugger is available by telnetting to your SmartEVSE device
 #define MODEM 0  //0 = no modem 1 = modem
@@ -629,6 +633,12 @@ void handleWIFImode(void);
 
 #if ENABLE_OCPP
 void ocppUpdateRfidReading(const unsigned char *uuid, size_t uuidLen);
+bool ocppIsConnectorPlugged();
+
+bool ocppHasTxNotification();
+MicroOcpp::TxNotification ocppGetTxNotification();
+
+bool ocppLockingTxDefined();
 #endif //ENABLE_OCPP
 
 #endif

--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -540,7 +540,7 @@ const struct {
     {"PWR SHARE", "Share Power between multiple SmartEVSEs (2-8)",    0, NR_EVSES, LOADBL},
     {"SWITCH",  "Switch function control on pin SW",                  0, 4, SWITCH},
     {"RCMON",   "Residual Current Monitor on pin RCM",                0, 1, RC_MON},
-    {"RFID",    "RFID reader, learn/remove cards",                    0, 5, RFID_READER},
+    {"RFID",    "RFID reader, learn/remove cards",                    0, 5 + (ENABLE_OCPP ? 1 : 0), RFID_READER},
     {"EV METER","Type of EV electric meter",                          0, EM_CUSTOM, EV_METER},
     {"EV ADDR", "Address of EV electric meter",                       MIN_METER_ADDRESS, MAX_METER_ADDRESS, EV_METER_ADDRESS},
 

--- a/SmartEVSE-3/src/OneWire.cpp
+++ b/SmartEVSE-3/src/OneWire.cpp
@@ -211,8 +211,7 @@ void CheckRFID(void) {
         if (OneWireReadCardId() ) {                                             // Read card ID
 #if ENABLE_OCPP
             uint8_t OcppMode = getItemValue(MENU_OCPP);
-            if (RFIDReader == 1 || // EnableAll                                     // Remote authorization via OCPP?
-                     RFIDReader == 2) { // EnableOne
+            if (OcppMode && RFIDReader == 6) {                                      // Remote authorization via OCPP?
                 // Use OCPP
 
                 static unsigned long lastread;
@@ -220,6 +219,7 @@ void CheckRFID(void) {
                     ocppUpdateRfidReading(RFID + 1, 7); // UUID starts at RFID+1; Assume 7-byte UUID for now
                     lastread = millis();
                 }
+                RFIDstatus = 1;
             } else
 #endif
             {

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -454,6 +454,36 @@ void BlinkLed(void * parameter) {
                 BluePwm = 0;
             }
 
+#if ENABLE_OCPP
+        } else if (OcppMode && millis() - OcppLastRfidUpdate < 200) {
+            RedPwm = 128;
+            GreenPwm = 128;
+            BluePwm = 128;
+        } else if (OcppMode && millis() - OcppLastTxNotification < 1000 && OcppTrackTxNotification == MicroOcpp::TxNotification::Authorized) {
+            RedPwm = 0;
+            GreenPwm = 255;
+            BluePwm = 0;
+        } else if (OcppMode && millis() - OcppLastTxNotification < 2000 && (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationRejected ||
+                                                                            OcppTrackTxNotification == MicroOcpp::TxNotification::DeAuthorized ||
+                                                                            OcppTrackTxNotification == MicroOcpp::TxNotification::ReservationConflict)) {
+            RedPwm = 255;
+            GreenPwm = 0;
+            BluePwm = 0;
+        } else if (OcppMode && millis() - OcppLastTxNotification < 300 && (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationTimeout ||
+                                                                           OcppTrackTxNotification == MicroOcpp::TxNotification::ConnectionTimeout)) {
+            RedPwm = 255;
+            GreenPwm = 0;
+            BluePwm = 0;
+        } else if (OcppMode && getChargePointStatus() == ChargePointStatus_Reserved) {
+            RedPwm = 196;
+            GreenPwm = 64;
+            BluePwm = 0;
+        } else if (OcppMode && (getChargePointStatus() == ChargePointStatus_Unavailable ||
+                                getChargePointStatus() == ChargePointStatus_Faulted)) {
+            RedPwm = 255;
+            GreenPwm = 0;
+            BluePwm = 0;
+#endif //ENABLE_OCPP
         } else if (Access_bit == 0 || State == STATE_MODEM_DENIED) {                                            // No Access, LEDs off
             RedPwm = 0;
             GreenPwm = 0;

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -5907,6 +5907,9 @@ void ocppLoop() {
         if (OcppUnlockConnectorOnEVSideDisconnect->getBool() && !OcppLockingTx->isActive()) {
             // No LockingTx mode configured (still, keep LockingTx until end of transaction because the config could be changed in the middle of tx)
             OcppLockingTx.reset();
+        } else if (OcppLockingTx->isAborted()) {
+            // LockingTx hasn't successfully started
+            OcppLockingTx.reset();
         } else if (transaction && transaction != OcppLockingTx) {
             // Another Tx has already started
             OcppLockingTx.reset();

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -141,7 +141,7 @@ uint8_t MainsMeterAddress = MAINS_METER_ADDRESS;
 uint8_t Grid = GRID;                                                        // Type of Grid connected to Sensorbox (0:4Wire / 1:3Wire )
 uint8_t EVMeter = EV_METER;                                                 // Type of EV electric meter (0: Disabled / Constants EM_*)
 uint8_t EVMeterAddress = EV_METER_ADDRESS;
-uint8_t RFIDReader = RFID_READER;                                           // RFID Reader (0:Disabled / 1:Enabled / 2:Enable One / 3:Learn / 4:Delete / 5:Delete All)
+uint8_t RFIDReader = RFID_READER;                                           // RFID Reader (0:Disabled / 1:Enabled / 2:Enable One / 3:Learn / 4:Delete / 5:Delete All / 6: Remote via OCPP)
 #if FAKE_RFID
 uint8_t Show_RFID = 0;
 #endif
@@ -3009,7 +3009,7 @@ void mqttPublishData() {
         MQTTclient.publish(MQTTprefix + "/ChargeCurrentOverride", String(OverrideCurrent), true, 0);
         MQTTclient.publish(MQTTprefix + "/Access", String(StrAccessBit[Access_bit]), true, 0);
         MQTTclient.publish(MQTTprefix + "/RFID", !RFIDReader ? "Not Installed" : RFIDstatus >= 8 ? "NOSTATUS" : StrRFIDStatusWeb[RFIDstatus], true, 0);
-        if (RFIDReader) {
+        if (RFIDReader && RFIDReader != 6) { //RFIDLastRead not updated in Remote/OCPP mode
             char buf[13];
             sprintf(buf, "%02X%02X%02X%02X%02X%02X", RFID[1], RFID[2], RFID[3], RFID[4], RFID[5], RFID[6]);
             MQTTclient.publish(MQTTprefix + "/RFIDLastRead", buf, true, 0);
@@ -4821,7 +4821,7 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
         doc["evse"]["error"] = error;
         doc["evse"]["error_id"] = errorId;
         doc["evse"]["rfid"] = !RFIDReader ? "Not Installed" : RFIDstatus >= 8 ? "NOSTATUS" : StrRFIDStatusWeb[RFIDstatus];
-        if (RFIDReader) {
+        if (RFIDReader && RFIDReader != 6) { //RFIDLastRead not updated in Remote/OCPP mode
             char buf[13];
             sprintf(buf, "%02X%02X%02X%02X%02X%02X", RFID[1], RFID[2], RFID[3], RFID[4], RFID[5], RFID[6]);
             doc["evse"]["rfid_lastread"] = buf;

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -800,7 +800,7 @@ const char * getMenuItemOption(uint8_t nav) {
     const static char StrGrid[2][10] = {"4Wire", "3Wire"};
     const static char StrEnabled[] = "Enabled";
     const static char StrExitMenu[] = "MENU";
-    const static char StrRFIDReader[6][10] = {"Disabled", "EnableAll", "EnableOne", "Learn", "Delete", "DeleteAll"};
+    const static char StrRFIDReader[7][10] = {"Disabled", "EnableAll", "EnableOne", "Learn", "Delete", "DeleteAll", "Rmt/OCPP"};
 #if ENABLE_OCPP
     const static char StrOcpp[2][10] = {"Disabled", "Enabled"};
 #endif

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -36,6 +36,10 @@
 #include "font.cpp"
 #include "font2.cpp"
 
+#if ENABLE_OCPP
+#include <MicroOcpp.h>
+#endif
+
 
 const unsigned char LCD_Flow [] = {
 0x00, 0x00, 0x98, 0xCC, 0x66, 0x22, 0x22, 0x22, 0xF2, 0xAA, 0x26, 0x2A, 0xF2, 0x22, 0x22, 0x22,
@@ -527,6 +531,49 @@ void GLCD(void) {
         glcd_clrln(6, 0x10);                                                    // horizontal line
         glcd_clrln(7, 0x00);
 
+#if ENABLE_OCPP
+        if (ocppHasTxNotification()) {
+            switch(ocppGetTxNotification()) {
+                case MicroOcpp::TxNotification::Authorized:
+                    GLCD_print_buf2(2, (const char *) "ACCEPTED");
+                    GLCD_print_buf2(4, (const char *) "RFID CARD");
+                    break;
+                case MicroOcpp::TxNotification::AuthorizationRejected:
+                case MicroOcpp::TxNotification::DeAuthorized:
+                    GLCD_print_buf2(2, (const char *) "INVALID");
+                    GLCD_print_buf2(4, (const char *) "RFID CARD");
+                    break;
+                case MicroOcpp::TxNotification::AuthorizationTimeout:
+                    GLCD_print_buf2(2, (const char *) "OFFLINE");
+                    GLCD_print_buf2(4, (const char *) "TRY LATER");
+                    break;
+                case MicroOcpp::TxNotification::ReservationConflict:
+                    GLCD_print_buf2(2, (const char *) "BLOCKED BY");
+                    GLCD_print_buf2(4, (const char *) "RESERVATION");
+                    break;
+                case MicroOcpp::TxNotification::ConnectionTimeout:
+                    GLCD_print_buf2(2, (const char *) "TIMEOUT");
+                    GLCD_print_buf2(4, (const char *) "TRY AGAIN");
+                    break;
+                case MicroOcpp::TxNotification::RemoteStart:
+                    if (!ocppIsConnectorPlugged()) {
+                        GLCD_print_buf2(2, (const char *) "PLUG IN");
+                        GLCD_print_buf2(4, (const char *) "VEHICLE");
+                    }
+                    break;
+                case MicroOcpp::TxNotification::StartTx:
+                    GLCD_print_buf2(2, (const char *) "STARTED");
+                    GLCD_print_buf2(4, (const char *) "TRANSACTION");
+                    break;
+                case MicroOcpp::TxNotification::StopTx:
+                    GLCD_print_buf2(2, (const char *) "STOPPED");
+                    GLCD_print_buf2(4, (const char *) "TRANSACTION");
+                    break;
+                default:
+                    break;
+            }
+        } else
+#endif //ENABLE_OCPP
         if (ErrorFlags & LESS_6A) {
             GLCD_print_buf2(2, (const char *) "WAITING");
             GLCD_print_buf2(4, (const char *) "FOR POWER");
@@ -558,6 +605,65 @@ void GLCD(void) {
                 } else Str[6] = '\0';
                 GLCD_print_buf2(4, Str);
             } else {
+#if ENABLE_OCPP
+                if (getItemValue(MENU_OCPP)) {
+                    switch (getChargePointStatus()) {
+                        case ChargePointStatus_Available:
+                            if (getItemValue(MENU_RFIDREADER) && getItemValue(MENU_RFIDREADER) != 6) {
+                                if (RFIDstatus == 7) {
+                                    GLCD_print_buf2(2, (const char *) "INVALID");
+                                    GLCD_print_buf2(4, (const char *) "RFID CARD");
+                                } else {
+                                    GLCD_print_buf2(2, (const char *) "PRESENT");
+                                    GLCD_print_buf2(4, (const char *) "RFID CARD");
+                                }
+                            } else {
+                                GLCD_print_buf2(2, (const char *) "AVAILABLE");
+                                GLCD_print_buf2(4, (const char *) "");
+                            }
+                            break;
+                        case ChargePointStatus_Preparing:
+                            if (!ocppIsConnectorPlugged()) {
+                                GLCD_print_buf2(2, (const char *) "PLUG IN");
+                                GLCD_print_buf2(4, (const char *) "VEHICLE");
+                            } else {
+                                GLCD_print_buf2(2, (const char *) "PLEASE");
+                                GLCD_print_buf2(4, (const char *) "AUTHORIZE");
+                            }
+                            break;
+                        case ChargePointStatus_Charging:
+                        case ChargePointStatus_SuspendedEVSE:
+                        case ChargePointStatus_SuspendedEV:
+                            // Should not be reached (Access_bit or STATE_C above prevail)
+                            GLCD_print_buf2(2, (const char *) "CHARGING");
+                            GLCD_print_buf2(4, (const char *) "IN PROGRESS");
+                            break;
+                        case ChargePointStatus_Finishing:
+                            if (ocppLockingTxDefined()) {
+                                GLCD_print_buf2(2, (const char *) "UNLOCK BY");
+                                GLCD_print_buf2(4, (const char *) "RFID CARD");
+                            } else {
+                                GLCD_print_buf2(2, (const char *) "FINISHED");
+                                GLCD_print_buf2(4, (const char *) "CHARGING");
+                            }
+                            break;
+                        case ChargePointStatus_Reserved:
+                            GLCD_print_buf2(2, (const char *) "RESERVED");
+                            GLCD_print_buf2(4, (const char *) "");
+                            break;
+                        case ChargePointStatus_Unavailable:
+                            GLCD_print_buf2(2, (const char *) "OUT OF");
+                            GLCD_print_buf2(4, (const char *) "ORDER");
+                            break;
+                        case ChargePointStatus_Faulted:
+                            GLCD_print_buf2(2, (const char *) "NO SERVICE");
+                            GLCD_print_buf2(4, (const char *) "");
+                            break;
+                        default:
+                            break;
+                    }
+                } else
+#endif //ENABLE_OCPP
                 if (getItemValue(MENU_RFIDREADER)) {
                     if (RFIDstatus == 7) {
                         GLCD_print_buf2(2, (const char *) "INVALID");


### PR DESCRIPTION
This PR adds a user dialog on the LCD display and further feedback over the LEDs.

The user dialog is quite extensive / technical and could be reduced again by a third. I'll leave it as it is for now as it simplifies troubleshooting and later we can still make it more user friendly.

At the moment, the LED feedback only covers the following scenarios:
- User swiped card
- Card accepted / rejected
- Charger reserved
- Charger out of order

No further changes were made to the existing colour scheme. However, I think that it could be worth experimenting more with the LEDs. For example, the LEDs remain off when a vehicle is plugged which appears like the charger is not reacting / out of order. Maybe, green should be used to signal that the charger is available to a new user, yellow is some in-progress / pending state and blue the final charging colour.

For the new user feedback, the RFIDReader needs to be extended by an explicit OCPP mode and EnableOne /-All cannot be reused anymore. Now, the RFID mode "Rmt/OCPP" needs to be selected in the RFID settings to work with OCPP. Furthermore, there was a bug with the mechanism to keep the lock closed until the user unlocks it by the same RFID card.

@dingo35 When you accept the changes, can you please merge instead of replaying the new code on master manually? That keeps it clearer how changes make it into the final code.