### PR TITLE
OCPP: truncate RFID (addresses #98)

### DIFF
--- a/SmartEVSE-3/src/OneWire.cpp
+++ b/SmartEVSE-3/src/OneWire.cpp
@@ -217,7 +217,7 @@ void CheckRFID(void) {
 
                 static unsigned long lastread;
                 if (OcppMode && millis() - lastread > 1500) {                       // Debounce 1500ms
-                    ocppUpdateRfidReading(RFID + 1, 7); // UUID starts at RFID+1; Assume 7-byte UUID for now
+                    ocppUpdateRfidReading(RFID + 1, 6); // UUID starts at RFID+1; Pad / truncate UUID to 6-bytes for now
                     lastread = millis();
                 }
             } else


### PR DESCRIPTION
Omit the 7th digit of the RFID reading as it only contains the first 6 bytes of the actual UUID. Change suggested by @fluppie in #98