### PR TITLE
OCPP: Add freevend settings

### DIFF
--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -272,10 +272,23 @@
                 document.getElementById("enable_ocpp_label").classList.add("ui-checkbox-off")
               }
 
+              if (data.ocpp.auto_auth == "Enabled") {
+                $('[id=ocpp_auto_auth_idtag_wrapper]').show();
+                document.getElementById("ocpp_auto_auth").checked = true;
+                document.getElementById("ocpp_auto_auth_label").classList.remove("ui-checkbox-off")
+                document.getElementById("ocpp_auto_auth_label").classList.add("ui-checkbox-on")
+              } else {
+                $('[id=ocpp_auto_auth_idtag_wrapper]').hide();
+                document.getElementById("ocpp_auto_auth").checked = false;
+                document.getElementById("ocpp_auto_auth_label").classList.remove("ui-checkbox-on")
+                document.getElementById("ocpp_auto_auth_label").classList.add("ui-checkbox-off")
+              }
+
               if (!ocppEditMode) {
                 $('#ocpp_backend_url').val(data.ocpp.backend_url);
                 $('#ocpp_cb_id').val(data.ocpp.cb_id);
                 $('#ocpp_auth_key').val(data.ocpp.auth_key);
+                $('#ocpp_auto_auth_idtag').val(data.ocpp.auto_auth_idtag);
               }
 
               $('#ocpp_ws_status').text(data.ocpp.status);
@@ -884,10 +897,11 @@
                     }
                     function toggleEnableOcpp() {
                       var enableOcppCheckbox = document.getElementById("enable_ocpp");
-                      // Get the output text
-                      var ocppSettingsDiv = document.getElementById("ocpp_settings");
-
                       $.post( "/settings?ocpp_update=1&ocpp_mode=" + (enableOcppCheckbox.checked == true ? 1 : 0));
+                    }
+                    function toggleEnableOcppAutoAuth() {
+                      var autoAuthCheckbox = document.getElementById("ocpp_auto_auth");
+                      $.post( "/settings?ocpp_update=1&ocpp_auto_auth=" + (autoAuthCheckbox.checked == true ? 1 : 0));
                     }
                     function toggleOcppEdit() {
                         ocppEditMode = !ocppEditMode;
@@ -896,27 +910,41 @@
                             $('#ocpp_backend_url').prop("disabled",false);
                             $('#ocpp_cb_id').prop("disabled",false);
                             $('#ocpp_auth_key').prop("disabled",false);
+                            $('#ocpp_auto_auth').prop("disabled",false);
+                            $('#ocpp_auto_auth_label').prop("disabled",false);
+                            $('#ocpp_auto_auth_idtag').prop("disabled",false);
                             document.getElementById("ocpp_backend_url").classList.remove("ui-state-disabled");
                             document.getElementById("ocpp_cb_id").classList.remove("ui-state-disabled");
                             document.getElementById("ocpp_auth_key").classList.remove("ui-state-disabled");
+                            document.getElementById("ocpp_auto_auth").classList.remove("ui-state-disabled");
+                            document.getElementById("ocpp_auto_auth_label").classList.remove("ui-state-disabled");
+                            document.getElementById("ocpp_auto_auth_idtag").classList.remove("ui-state-disabled");
                         } else {
                             configureOcpp();
                             $('#ocpp_save_btn').text("Edit Settings");
                             $('#ocpp_backend_url').prop("disabled",true);
                             $('#ocpp_cb_id').prop("disabled",true);
                             $('#ocpp_auth_key').prop("disabled",true);
+                            $('#ocpp_auto_auth').prop("disabled",true);
+                            $('#ocpp_auto_auth_label').prop("disabled",true);
+                            $('#ocpp_auto_auth_idtag').prop("disabled",true);
                             document.getElementById("ocpp_backend_url").classList.add("ui-state-disabled");
                             document.getElementById("ocpp_cb_id").classList.add("ui-state-disabled");
                             document.getElementById("ocpp_auth_key").classList.add("ui-state-disabled");
+                            document.getElementById("ocpp_auto_auth").classList.add("ui-state-disabled");
+                            document.getElementById("ocpp_auto_auth_label").classList.add("ui-state-disabled");
+                            document.getElementById("ocpp_auto_auth_idtag").classList.add("ui-state-disabled");
                         }
                     }
                     function configureOcpp() {
                         var ocpp_backend_url=$('#ocpp_backend_url').val();
                         var ocpp_cb_id=$('#ocpp_cb_id').val();
                         var ocpp_auth_key=$('#ocpp_auth_key').val();
+                        var ocpp_auto_auth_idtag=$('#ocpp_auto_auth_idtag').val();
 
                         $.post( "/settings?ocpp_update=1&ocpp_backend_url=" + ocpp_backend_url +
-                            "&ocpp_cb_id=" + ocpp_cb_id + "&ocpp_auth_key=" + ocpp_auth_key);
+                            "&ocpp_cb_id=" + ocpp_cb_id + "&ocpp_auth_key=" + ocpp_auth_key +
+                            "&ocpp_auto_auth_idtag=" + ocpp_auto_auth_idtag);
 
                         event.preventDefault();
                     }
@@ -1092,6 +1120,17 @@
                                               <label>Backend URL: <input id="ocpp_backend_url" class="ui-state-disabled"></label>
                                               <label>Charge Box Id: <input id="ocpp_cb_id" class="ui-state-disabled"></label>
                                               <label>Authentication key: <input id="ocpp_auth_key" class="ui-state-disabled"></label>
+                                              <div class="row no-gutters align-items-center" style="margin-top:20px;margin-bottom:10px">
+                                                <div class="col-auto mb-0 mr-3" style="width: 200px">
+                                                  <input type="checkbox" class="form-check-input ui-state-disabled" id="ocpp_auto_auth" onclick="toggleEnableOcppAutoAuth()">
+                                                  <label class="form-check-label ui-state-disabled" for="ocpp_auto_auth" id="ocpp_auto_auth_label">Auto-authorize</label>
+                                                </div>
+                                                <div class="col">
+                                                  <div class="mb-0" id="ocpp_auto_auth_idtag_wrapper">
+                                                    <input id="ocpp_auto_auth_idtag" class="ui-state-disabled" placeholder="Default idTag">
+                                                  </div>
+                                                </div>
+                                              </div>
                                               <button id="ocpp_save_btn" onclick="toggleOcppEdit()" style="display:inline-block;">Edit Settings</button>
                                           </div>
                                         </div>

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -5238,8 +5238,8 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                 // Apply changes in OcppWsClient
                 if (OcppWsClient) {
                     OcppWsClient->reloadConfigs();
-                    MicroOcpp::configuration_save();
                 }
+                MicroOcpp::configuration_save();
                 write_settings();
             }
         }

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -4877,6 +4877,13 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
         doc["ocpp"]["cb_id"] = OcppWsClient ? OcppWsClient->getChargeBoxId() : "";
         doc["ocpp"]["auth_key"] = OcppWsClient ? OcppWsClient->getAuthKey() : "";
 
+        {
+            auto freevendMode = MicroOcpp::getConfigurationPublic(MO_CONFIG_EXT_PREFIX "FreeVendActive");
+            doc["ocpp"]["auto_auth"] = freevendMode && freevendMode->getBool() ? "Enabled" : "Disabled";
+            auto freevendIdTag = MicroOcpp::getConfigurationPublic(MO_CONFIG_EXT_PREFIX "FreeVendIdTag");
+            doc["ocpp"]["auto_auth_idtag"] = freevendIdTag ? freevendIdTag->getString() : "";
+        }
+
         if (OcppWsClient && OcppWsClient->isConnected()) {
             doc["ocpp"]["status"] = "Connected";
         } else {
@@ -5208,9 +5215,30 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                     }
                 }
 
+                if(request->hasParam("ocpp_auto_auth")) {
+                    auto freevendMode = MicroOcpp::getConfigurationPublic(MO_CONFIG_EXT_PREFIX "FreeVendActive");
+                    if (freevendMode) {
+                        freevendMode->setBool(request->getParam("ocpp_auto_auth")->value().toInt());
+                        doc["ocpp_auto_auth"] = freevendMode->getBool() ? 1 : 0;
+                    } else {
+                        doc["ocpp_auto_auth"] = "Can only update when OCPP enabled";
+                    }
+                }
+
+                if(request->hasParam("ocpp_auto_auth_idtag")) {
+                    auto freevendIdTag = MicroOcpp::getConfigurationPublic(MO_CONFIG_EXT_PREFIX "FreeVendIdTag");
+                    if (freevendIdTag) {
+                        freevendIdTag->setString(request->getParam("ocpp_auto_auth_idtag")->value().c_str());
+                        doc["ocpp_auto_auth_idtag"] = freevendIdTag->getString();
+                    } else {
+                        doc["ocpp_auto_auth_idtag"] = "Can only update when OCPP enabled";
+                    }
+                }
+
                 // Apply changes in OcppWsClient
                 if (OcppWsClient) {
                     OcppWsClient->reloadConfigs();
+                    MicroOcpp::configuration_save();
                 }
                 write_settings();
             }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,9 @@ RCMON   RCM14-03 Residual Current Monitor is plugged into connector P1
 RFID    use a RFID card reader to enable/disable access to the EVSE
         A maximum of 20 RFID cards can be stored.
                 <Disabled> / <Enabled> / <Learn> / <Delete> / <Delete All>
+  <Rmt/OCPP>  Authorize remotely over OCPP and bypass the SmartEVSE local RFID storage. For
+              offline storage, use OCPP local lists. SmartEVSE sends RFID readings to the
+              OCPP server in this mode only.
 
 WIFI          Enable wifi connection to your LAN
   <Disabled>  No wifi connection
@@ -130,6 +133,15 @@ WIFI          Enable wifi connection to your LAN
               -wait for 120s ; then press enter on your serial terminal; you will be prompted for your WiFi
                network name and password.
   <Enabled>   Connect to your LAN via Wifi.
+
+OCPP          Enable OCPP
+              See the OCPP section in the SmartEVSE dashboard for setting up identifiers and configuring
+              the OCPP interface.
+  <Disabled>  No OCPP functionality including OCPP access control and load managment
+  <Enabled>   Connect to the OCPP server using the credentials set up in the SmartEVSE dashboard. To use
+              the RFID reader with OCPP, set the mode Rmt/OCPP in the RFID menu. Note that the other
+              RFID modes overrule the OCPP access control. OCPP SmartCharging requires the SmartEVSE
+              internal load balancing means to be turned off.
 
 AUTOUPDAT     (only appears when WIFI is Enabled):
               Automatic update of your firmware

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,10 +97,21 @@ RCMON   RCM14-03 Residual Current Monitor is plugged into connector P1
 
 RFID    use a RFID card reader to enable/disable access to the EVSE
         A maximum of 20 RFID cards can be stored.
-                <Disabled> / <Enabled> / <Learn> / <Delete> / <Delete All>
+  <Disabled>  RFID reader turned off
+  <EnableAll> Accept all learned cards for enabling/disabling the SmartEVSE
+  <EnableOne> Only allow a single (learned) card to be used for enabling/disabling the
+              SmartEVSE. In this mode the lock (if used) will lock the cable in the charging
+              socket, and the same card is used to unlock it again
+  <Learn>     Learn a new card and store it into the SmartEVSE. Make sure you stay in the
+              menu when learning cards. Present a card in front of the reader. "Card Stored"
+              will be shown on the LCD
+  <Delete>    Erase a previous learned card. Hold the card in front of the reader. "Card
+              Deleted" will be shown on the LCD once the card has been deleted
+  <DeleteAll> Erase all cards from the SmartEVSE. The cards will be erased once you exit
+              the menu of the SmartEVSE
   <Rmt/OCPP>  Authorize remotely over OCPP and bypass the SmartEVSE local RFID storage. For
               offline storage, use OCPP local lists. SmartEVSE sends RFID readings to the
-              OCPP server in this mode only.
+              OCPP server in this mode only
 
 WIFI          Enable wifi connection to your LAN
   <Disabled>  No wifi connection


### PR DESCRIPTION
Add a new checkbox and textfield to the dashboard for changing the freevend settings. In the dashboard, freevend is referred to as "Auto-authorize", because I believe it is easier to understand.