### PR TITLE
MQTT: Fix number template

### DIFF
--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -3018,7 +3018,7 @@ void SetupMQTTClient() {
 
     //set the parameters for and announce number entities:
     optional_payload = jsna("command_topic", String(MQTTprefix + "/Set/CurrentOverride")) + jsna("min", "0") + jsna("max", MaxCurrent ) + jsna("mode","slider");
-    optional_payload += jsna("value_template", R"({{ none if (value | int == 0) else (value | int / 10) }})") + jsna("command_template", R"({{ value | int * 10 }})");
+    optional_payload += jsna("value_template", R"({{ value | int / 10 if value | is_number else none }})") + jsna("command_template", R"({{ value | int * 10 }})");
     announce("Charge Current Override", "number");
 }
 


### PR DESCRIPTION
The current template doesn't handle empty values correctly, leading to an error in Home Assistant:

```
Logger: homeassistant.components.mqtt.mixins
Bron: components/mqtt/mixins.py:1273
integratie: MQTT ([documentatie](https://www.home-assistant.io/integrations/mqtt), [problemen](https://github.com/home-assistant/core/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+mqtt%22))
Eerst voorgekomen: 12:59:08 (1 gebeurtenissen)
Laatst gelogd: 12:59:08

ValueError: Template error: int got invalid input '' when rendering template '{{ none if (value | int == 0) else (value | int / 10) }}' but no default was specified rendering template for entity 'number.smartevse_6360_chargecurrentoverride', template: '{{ none if (value | int == 0) else (value | int / 10) }}' and payload:`
```
This PR makes the template more robust to handle empty values better.

Tx to @TheFes @ Dutch Domotics Discord
