### PR TITLE
OCPP: Allow using SmartEVSE local RFID storage with OCPP

### DIFF
--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -456,31 +456,37 @@ void BlinkLed(void * parameter) {
             }
 
 #if ENABLE_OCPP
-        } else if (OcppMode && millis() - OcppLastRfidUpdate < 200) {
+        } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
+                    millis() - OcppLastRfidUpdate < 200) {
             RedPwm = 128;
             GreenPwm = 128;
             BluePwm = 128;
-        } else if (OcppMode && millis() - OcppLastTxNotification < 1000 && OcppTrackTxNotification == MicroOcpp::TxNotification::Authorized) {
+        } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
+                    millis() - OcppLastTxNotification < 1000 && OcppTrackTxNotification == MicroOcpp::TxNotification::Authorized) {
             RedPwm = 0;
             GreenPwm = 255;
             BluePwm = 0;
-        } else if (OcppMode && millis() - OcppLastTxNotification < 2000 && (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationRejected ||
-                                                                            OcppTrackTxNotification == MicroOcpp::TxNotification::DeAuthorized ||
-                                                                            OcppTrackTxNotification == MicroOcpp::TxNotification::ReservationConflict)) {
+        } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
+                    millis() - OcppLastTxNotification < 2000 && (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationRejected ||
+                                                                 OcppTrackTxNotification == MicroOcpp::TxNotification::DeAuthorized ||
+                                                                 OcppTrackTxNotification == MicroOcpp::TxNotification::ReservationConflict)) {
             RedPwm = 255;
             GreenPwm = 0;
             BluePwm = 0;
-        } else if (OcppMode && millis() - OcppLastTxNotification < 300 && (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationTimeout ||
-                                                                           OcppTrackTxNotification == MicroOcpp::TxNotification::ConnectionTimeout)) {
+        } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
+                    millis() - OcppLastTxNotification < 300 && (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationTimeout ||
+                                                                OcppTrackTxNotification == MicroOcpp::TxNotification::ConnectionTimeout)) {
             RedPwm = 255;
             GreenPwm = 0;
             BluePwm = 0;
-        } else if (OcppMode && getChargePointStatus() == ChargePointStatus_Reserved) {
+        } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
+                    getChargePointStatus() == ChargePointStatus_Reserved) {
             RedPwm = 196;
             GreenPwm = 64;
             BluePwm = 0;
-        } else if (OcppMode && (getChargePointStatus() == ChargePointStatus_Unavailable ||
-                                getChargePointStatus() == ChargePointStatus_Faulted)) {
+        } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
+                    (getChargePointStatus() == ChargePointStatus_Unavailable ||
+                     getChargePointStatus() == ChargePointStatus_Faulted)) {
             RedPwm = 255;
             GreenPwm = 0;
             BluePwm = 0;
@@ -5879,6 +5885,7 @@ void ocppDeinit() {
     }
 
     OcppTrackPermitsCharge = false;
+    OcppTrackAccessBit = false;
     OcppTrackCPvoltage = PILOT_NOK;
     OcppCurrentLimit = -1.f;
 

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -532,7 +532,9 @@ void GLCD(void) {
         glcd_clrln(7, 0x00);
 
 #if ENABLE_OCPP
-        if (ocppHasTxNotification()) {
+        if (getItemValue(MENU_OCPP) &&                                          // OCPP enabled
+                (getItemValue(MENU_RFIDREADER) == 6 || getItemValue(MENU_RFIDREADER) == 0) && // RFID in OCPP mode or disabled
+                ocppHasTxNotification()) {                                      // There is an OCPP event to display
             switch(ocppGetTxNotification()) {
                 case MicroOcpp::TxNotification::Authorized:
                     GLCD_print_buf2(2, (const char *) "ACCEPTED");
@@ -606,21 +608,12 @@ void GLCD(void) {
                 GLCD_print_buf2(4, Str);
             } else {
 #if ENABLE_OCPP
-                if (getItemValue(MENU_OCPP)) {
+                if (getItemValue(MENU_OCPP) &&                                  // OCPP enabled
+                        (getItemValue(MENU_RFIDREADER) == 6 || getItemValue(MENU_RFIDREADER) == 0)) { // RFID in OCPP mode or disabled
                     switch (getChargePointStatus()) {
                         case ChargePointStatus_Available:
-                            if (getItemValue(MENU_RFIDREADER) && getItemValue(MENU_RFIDREADER) != 6) {
-                                if (RFIDstatus == 7) {
-                                    GLCD_print_buf2(2, (const char *) "INVALID");
-                                    GLCD_print_buf2(4, (const char *) "RFID CARD");
-                                } else {
-                                    GLCD_print_buf2(2, (const char *) "PRESENT");
-                                    GLCD_print_buf2(4, (const char *) "RFID CARD");
-                                }
-                            } else {
-                                GLCD_print_buf2(2, (const char *) "AVAILABLE");
-                                GLCD_print_buf2(4, (const char *) "");
-                            }
+                            GLCD_print_buf2(2, (const char *) "AVAILABLE");
+                            GLCD_print_buf2(4, (const char *) "");
                             break;
                         case ChargePointStatus_Preparing:
                             if (!ocppIsConnectorPlugged()) {


### PR DESCRIPTION
This PR adds a mode for using the local RFID storage with OCPP.

The new mode leaves the access control functionality to the existing SmartEVSE RFID module, but still sends the UUID and charging monitoring data to the OCPP backend. Consequently, RFID cards don't need to be accepted by the OCPP backend.

Since the display text and LED feedback could be confusing, the OCPP parts are fully disabled. The user can view the OCPP status only in the backend.

SmartEVSE will use this mode when OCPP enabled and RFID is enabled too, but not in the Rmt/OCPP mode. So RFID modes EnableOne/EnableAll mean that the SmartEVSE continues to use its local RFID storage as without OCPP, but OCPP will still monitor the charger (e.g. to record the charging sessions). RFID mode Rmt/OCPP means that cards must be authorized by the OCPP server in order to charge and the SmartEVSE RFID storage is bypassed.

Note: OCPP also has LocalLists for offline authorization which can be managed by the server. These are separate from the SmartEVSE RFID storage. SmartEVSE will use OCPP LocalLists in the Rmt/OCPP mode.