### PR TITLE
Add MQTT and REST API to control the connected LED in EVSE 'Off' mode

### DIFF
--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -4831,6 +4831,10 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
         doc["backlight"]["timer"] = BacklightTimer;
         doc["backlight"]["status"] = backlight;
 
+        doc["color_off"]["R"] = ColorOff[0];
+        doc["color_off"]["G"] = ColorOff[1];
+        doc["color_off"]["B"] = ColorOff[2];
+
         String json;
         serializeJson(doc, json);
         mg_http_reply(c, 200, "Content-Type: application/json\r\n", "%s\n", json.c_str());    // Yes. Respond JSON
@@ -5158,6 +5162,30 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
       } else {
         mg_http_reply(c, 404, "", "Not Found\n");
       }
+    } else if (mg_http_match_uri(hm, "/color_off") && !memcmp("POST", hm->method.buf, hm->method.len)) {
+        DynamicJsonDocument doc(200);
+        
+        if (request->hasParam("R") && request->hasParam("G") && request->hasParam("B")) {
+            int32_t R = request->getParam("R")->value().toInt();
+            int32_t G = request->getParam("G")->value().toInt();
+            int32_t B = request->getParam("B")->value().toInt();
+
+            // R,G,B is between 0..255
+            if ((R >= 0 && R < 256) && (G >= 0 && G < 256) && (B >= 0 && B < 256)) {
+                ColorOff[0] = R;
+                ColorOff[1] = G;
+                ColorOff[2] = B;
+                doc["color_off"]["R"] = ColorOff[0];
+                doc["color_off"]["G"] = ColorOff[1];
+                doc["color_off"]["B"] = ColorOff[2];
+            }
+        }
+
+
+        String json;
+        serializeJson(doc, json);
+        mg_http_reply(c, 200, "Content-Type: application/json\r\n", "%s\r\n", json.c_str());    // Yes. Respond JSON
+
     } else if (mg_http_match_uri(hm, "/currents") && !memcmp("POST", hm->method.buf, hm->method.len)) {
         DynamicJsonDocument doc(200);
 

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -255,6 +255,7 @@ int homeBatteryLastUpdate = 0; // Time in milliseconds
 char *downloadUrl = NULL;
 int downloadProgress = 0;
 int downloadSize = 0;
+uint Cheap_tariff_ahead = 0;                                               // set by EXTERNAL logic through MQTT/REST to indicate cheap tariffs ahead until unix time indicated
 //#define FW_UPDATE_DELAY 30        //DINGO TODO                                            // time between detection of new version and actual update in seconds
 #define FW_UPDATE_DELAY 3600                                                    // time between detection of new version and actual update in seconds
 uint16_t firmwareUpdateTimer = 0;                                               // timer for firmware updates in seconds, max 0xffff = approx 18 hours
@@ -454,11 +455,18 @@ void BlinkLed(void * parameter) {
             GreenPwm = 0;
             BluePwm = 0;
 #endif //ENABLE_OCPP
-        } else if (Access_bit == 0 || State == STATE_MODEM_DENIED) {                                            // No Access, LEDs off
-            RedPwm = 0;
-            GreenPwm = 0;
-            BluePwm = 0;
-            LedPwm = 0;                  
+        } else if (Access_bit == 0 || State == STATE_MODEM_DENIED) {
+            if (Cheap_tariff_ahead > time(NULL)) {                  // No access, indicates with BLUE that a cheap tariff is ahead (until current time exceeds set time)
+                RedPwm = 0;
+                GreenPwm = 0;
+                BluePwm = 255;
+                LedPwm = 128;
+            } else {                                                // No Access, LEDs off
+                RedPwm = 0;
+                GreenPwm = 0;
+                BluePwm = 0;
+                LedPwm = 0; 
+            }
         } else {                                                                // State A, B or C
     
             if (State == STATE_A) {
@@ -2832,6 +2840,8 @@ void mqtt_receive_callback(const String topic, const String payload) {
             preferences.putString("RequiredEVCCID", String(RequiredEVCCID));
             preferences.end();
         }
+    } else if (topic == MQTTprefix + "/Set/CheapTariffIndicator") {
+        Cheap_tariff_ahead = payload.toInt();
     }
 
     // Make sure MQTT updates directly to prevent debounces
@@ -3068,6 +3078,7 @@ void mqttPublishData() {
         MQTTclient.publish(MQTTprefix + "/OCPP", OcppMode ? "Enabled" : "Disabled", true, 0);
         MQTTclient.publish(MQTTprefix + "/OCPPConnection", (OcppWsClient && OcppWsClient->isConnected()) ? "Connected" : "Disconnected", false, 0);
 #endif //ENABLE_OCPP
+        MQTTclient.publish(MQTTprefix + "/CheapTariffIndicator", (Cheap_tariff_ahead>0) ? String(Cheap_tariff_ahead) : "Disabled", true, 0);
 }
 #endif
 

--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -133,6 +133,15 @@ to your curl POST command. -d ''
 <br>&emsp;&emsp;Usually you should leave this setting at its default value (600A)
 <br>&emsp;&emsp;since your electricity provider probably does not supports this.
 
+# POST: /color_off
+
+* R, G, B
+
+<br>&emsp;&emsp;R, G and B must be send all together otherwise the data won't be registered.
+```
+    curl -X POST 'http://ipaddress/color_off?R=0&G=0&B=255' -d ''
+```
+
 # POST: /currents
 
 * battery_current

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,6 +243,7 @@ Valid topics you can publish to are:
 /Set/EVMeter
 /Set/HomeBatteryCurrent
 /Set/RequiredEVCCID
+/Set/ColorOff
 ```
 Your MainsMeter can be fed with:
 ```


### PR DESCRIPTION
This PR expands the MQTT and REST API with topics / endpoints to set the color of a connected LED when the EVSE is in 'Off' mode. See discussion in [this feature request ](https://github.com/dingo35/SmartEVSE-3.5/issues/129)

Also includes:
- update of the REST API description: http://ipaddress/color_off?R=0&G=0&B=255
- update of the MQTT topic list to publish to: /Set/ColorOff
