### PR TITLE
Feature Custom Button

### DIFF
--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -520,7 +520,7 @@ const struct {
     {"MIN",     "MIN Charge Current the EV will accept (per phase)",  MIN_CURRENT, 16, MIN_CURRENT},
     {"MAX",     "MAX Charge Current for this EVSE (per phase)",       6, 80, MAX_CURRENT},
     {"PWR SHARE", "Share Power between multiple SmartEVSEs (2-8)",    0, NR_EVSES, LOADBL},
-    {"SWITCH",  "Switch function control on pin SW",                  0, 5, SWITCH},
+    {"SWITCH",  "Switch function control on pin SW",                  0, 7, SWITCH},
     {"RCMON",   "Residual Current Monitor on pin RCM",                0, 1, RC_MON},
     {"RFID",    "RFID reader, learn/remove cards",                    0, 5 + (ENABLE_OCPP ? 1 : 0), RFID_READER},
     {"EV METER","Type of EV electric meter",                          0, EM_CUSTOM, EV_METER},

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -2100,6 +2100,7 @@ void CheckSwitch(bool force = false)
                         GridRelayOpen = false;
                         break;
                     case 6: // Custom button B
+                        CustomButton = !CustomButton;
                         break;
                     case 7: // Custom button S
                         CustomButton = true;
@@ -2149,7 +2150,6 @@ void CheckSwitch(bool force = false)
                         GridRelayOpen = true;
                         break;
                     case 6: // Custom button B
-                        CustomButton = !CustomButton;
                         break;
                     case 7: // Custom button S
                         CustomButton = false;

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -494,7 +494,7 @@ void BlinkLed(void * parameter) {
                 RedPwm = LedPwm * ColorCustom[0] / 255;
                 GreenPwm = LedPwm * ColorCustom[1] / 255;
                 BluePwm = LedPwm * ColorCustom[2] / 255;
-            } if (Mode == MODE_SOLAR) {                                     // Orange for Solar, unless configured otherwise
+            } else if (Mode == MODE_SOLAR) {                                // Orange for Solar, unless configured otherwise
                 RedPwm = LedPwm * ColorSolar[0] / 255;
                 GreenPwm = LedPwm * ColorSolar[1] / 255;
                 BluePwm = LedPwm * ColorSolar[2] / 255;

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -261,6 +261,7 @@ uint8_t ColorOff[3] = {0, 0, 0};          // off
 uint8_t ColorNormal[3] = {0, 255, 0};   // Green
 uint8_t ColorSmart[3] = {0, 255, 0};    // Green
 uint8_t ColorSolar[3] = {255, 170, 0};    // Orange
+uint8_t ColorCustom[3] = {0, 0, 255};    // Blue
 
 //#define FW_UPDATE_DELAY 30        //DINGO TODO                                            // time between detection of new version and actual update in seconds
 #define FW_UPDATE_DELAY 3600                                                    // time between detection of new version and actual update in seconds
@@ -415,7 +416,11 @@ void BlinkLed(void * parameter) {
                 if (LedCount > 230) LedPwm = WAITING_LED_BRIGHTNESS;            // LED 10% of time on, full brightness
                 else LedPwm = 0;
 
-                if (Mode == MODE_SOLAR) {                                       // Orange for Solar, unless configured otherwise
+                if (CustomButton) {                                             // Blue for Custom, unless configured otherwise
+                    RedPwm = LedPwm * ColorCustom[0] / 255;
+                    GreenPwm = LedPwm * ColorCustom[1] / 255;
+                    BluePwm = LedPwm * ColorCustom[2] / 255;
+                } else if (Mode == MODE_SOLAR) {                                // Orange for Solar, unless configured otherwise
                     RedPwm = LedPwm * ColorSolar[0] / 255;
                     GreenPwm = LedPwm * ColorSolar[1] / 255;
                     BluePwm = LedPwm * ColorSolar[2] / 255;
@@ -485,7 +490,11 @@ void BlinkLed(void * parameter) {
                 LedPwm = ease8InOutQuad(triwave8(LedCount));                    // pre calculate new LedPwm value
             }
 
-            if (Mode == MODE_SOLAR) {                                       // Orange for Solar, unless configured otherwise
+            if (CustomButton) {                                             // Blue for Custom, unless configured otherwise
+                RedPwm = LedPwm * ColorCustom[0] / 255;
+                GreenPwm = LedPwm * ColorCustom[1] / 255;
+                BluePwm = LedPwm * ColorCustom[2] / 255;
+            } if (Mode == MODE_SOLAR) {                                     // Orange for Solar, unless configured otherwise
                 RedPwm = LedPwm * ColorSolar[0] / 255;
                 GreenPwm = LedPwm * ColorSolar[1] / 255;
                 BluePwm = LedPwm * ColorSolar[2] / 255;
@@ -2912,6 +2921,16 @@ void mqtt_receive_callback(const String topic, const String payload) {
             ColorSolar[1] = G;
             ColorSolar[2] = B;
         }
+    } else if (topic == MQTTprefix + "/Set/ColorCustom") {
+        int32_t R, G, B;
+        int n = sscanf(payload.c_str(), "%d:%d:%d", &R, &G, &B);
+
+        // R,G,B is between 0..255
+        if (n == 3 && (R >= 0 && R < 256) && (G >= 0 && G < 256) && (B >= 0 && B < 256)) {
+            ColorCustom[0] = R;
+            ColorCustom[1] = G;
+            ColorCustom[2] = B;
+        }
     }
 
     // Make sure MQTT updates directly to prevent debounces
@@ -3053,6 +3072,17 @@ void SetupMQTTClient() {
     announce("State", "sensor");
     announce("RFID", "sensor");
     announce("RFIDLastRead", "sensor");
+
+    optional_payload = jsna("state_topic", String(MQTTprefix + "/LEDColorOff")) + jsna("command_topic", String(MQTTprefix + "/Set/ColorOff"));
+    announce("LED Color Off", "text");
+    optional_payload = jsna("state_topic", String(MQTTprefix + "/LEDColorNormal")) + jsna("command_topic", String(MQTTprefix + "/Set/ColorNormal"));
+    announce("LED Color Normal", "text");
+    optional_payload = jsna("state_topic", String(MQTTprefix + "/LEDColorSmart")) + jsna("command_topic", String(MQTTprefix + "/Set/ColorSmart"));
+    announce("LED Color Smart", "text");
+    optional_payload = jsna("state_topic", String(MQTTprefix + "/LEDColorSolar")) + jsna("command_topic", String(MQTTprefix + "/Set/ColorSolar"));
+    announce("LED Color Solar", "text");
+    optional_payload = jsna("state_topic", String(MQTTprefix + "/LEDColorCustom")) + jsna("command_topic", String(MQTTprefix + "/Set/ColorCustom"));
+    announce("LED Color Custom", "text");
     
     optional_payload = jsna("state_topic", String(MQTTprefix + "/CustomButton")) + jsna("command_topic", String(MQTTprefix + "/Set/CustomButton"));
     optional_payload += String(R"(, "options" : ["On", "Off"])");
@@ -3158,6 +3188,7 @@ void mqttPublishData() {
         MQTTclient.publish(MQTTprefix + "/LEDColorNormal", String(ColorNormal[0])+","+String(ColorNormal[1])+","+String(ColorNormal[2]), true, 0);
         MQTTclient.publish(MQTTprefix + "/LEDColorSmart", String(ColorSmart[0])+","+String(ColorSmart[1])+","+String(ColorSmart[2]), true, 0);
         MQTTclient.publish(MQTTprefix + "/LEDColorSolar", String(ColorSolar[0])+","+String(ColorSolar[1])+","+String(ColorSolar[2]), true, 0);
+        MQTTclient.publish(MQTTprefix + "/LEDColorCustom", String(ColorCustom[0])+","+String(ColorCustom[1])+","+String(ColorCustom[2]), true, 0);
 }
 #endif
 
@@ -4921,6 +4952,9 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
         doc["color"]["solar"]["R"] = ColorSolar[0];
         doc["color"]["solar"]["G"] = ColorSolar[1];
         doc["color"]["solar"]["B"] = ColorSolar[2];
+        doc["color"]["custom"]["R"] = ColorCustom[0];
+        doc["color"]["custom"]["G"] = ColorCustom[1];
+        doc["color"]["custom"]["B"] = ColorCustom[2];
 
         String json;
         serializeJson(doc, json);
@@ -5339,6 +5373,29 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                 doc["color"]["solar"]["R"] = ColorSolar[0];
                 doc["color"]["solar"]["G"] = ColorSolar[1];
                 doc["color"]["solar"]["B"] = ColorSolar[2];
+            }
+        }
+
+        String json;
+        serializeJson(doc, json);
+        mg_http_reply(c, 200, "Content-Type: application/json\r\n", "%s\r\n", json.c_str());    // Yes. Respond JSON
+
+    } else if (mg_http_match_uri(hm, "/color_custom") && !memcmp("POST", hm->method.buf, hm->method.len)) {
+        DynamicJsonDocument doc(200);
+        
+        if (request->hasParam("R") && request->hasParam("G") && request->hasParam("B")) {
+            int32_t R = request->getParam("R")->value().toInt();
+            int32_t G = request->getParam("G")->value().toInt();
+            int32_t B = request->getParam("B")->value().toInt();
+
+            // R,G,B is between 0..255
+            if ((R >= 0 && R < 256) && (G >= 0 && G < 256) && (B >= 0 && B < 256)) {
+                ColorCustom[0] = R;
+                ColorCustom[1] = G;
+                ColorCustom[2] = B;
+                doc["color"]["solar"]["R"] = ColorCustom[0];
+                doc["color"]["solar"]["G"] = ColorCustom[1];
+                doc["color"]["solar"]["B"] = ColorCustom[2];
             }
         }
 

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -5398,9 +5398,9 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                 ColorCustom[0] = R;
                 ColorCustom[1] = G;
                 ColorCustom[2] = B;
-                doc["color"]["solar"]["R"] = ColorCustom[0];
-                doc["color"]["solar"]["G"] = ColorCustom[1];
-                doc["color"]["solar"]["B"] = ColorCustom[2];
+                doc["color"]["custom"]["R"] = ColorCustom[0];
+                doc["color"]["custom"]["G"] = ColorCustom[1];
+                doc["color"]["custom"]["B"] = ColorCustom[2];
             }
         }
 

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -136,7 +136,8 @@ uint16_t MaxCircuit = MAX_CIRCUIT;                                          // M
 uint8_t Config = CONFIG;                                                    // Configuration (0:Socket / 1:Fixed Cable)
 uint8_t LoadBl = LOADBL;                                                    // Load Balance Setting (0:Disable / 1:Master / 2-8:Node)
 uint8_t Switch = SWITCH;                                                    // External Switch (0:Disable / 1:Access B / 2:Access S / 
-                                                                            // 3:Smart-Solar B / 4:Smart-Solar S / 5: Grid Relay)
+                                                                            // 3:Smart-Solar B / 4:Smart-Solar S / 5: Grid Relay
+                                                                            // 6:Custom B / 7:Custom S)
                                                                             // B=momentary push <B>utton, S=toggle <S>witch
 uint8_t RCmon = RC_MON;                                                     // Residual Current Monitor (0:Disable / 1:Enable)
 uint8_t AutoUpdate = AUTOUPDATE;                                            // Automatic Firmware Update (0:Disable / 1:Enable)

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -471,6 +471,10 @@ void BlinkLed(void * parameter) {
             GreenPwm = 0;
             BluePwm = 0;
 #endif //ENABLE_OCPP
+        } else if (Access_bit == 0 && CustomButton) {
+            RedPwm = ColorCustom[0];
+            GreenPwm = ColorCustom[1];
+            BluePwm = ColorCustom[2];
         } else if (Access_bit == 0 || State == STATE_MODEM_DENIED) {
             RedPwm = ColorOff[0];
             GreenPwm = ColorOff[1];
@@ -2883,7 +2887,7 @@ void mqtt_receive_callback(const String topic, const String payload) {
         }
     } else if (topic == MQTTprefix + "/Set/ColorOff") {
         int32_t R, G, B;
-        int n = sscanf(payload.c_str(), "%d:%d:%d", &R, &G, &B);
+        int n = sscanf(payload.c_str(), "%d,%d,%d", &R, &G, &B);
 
         // R,G,B is between 0..255
         if (n == 3 && (R >= 0 && R < 256) && (G >= 0 && G < 256) && (B >= 0 && B < 256)) {
@@ -2893,7 +2897,7 @@ void mqtt_receive_callback(const String topic, const String payload) {
         }
     } else if (topic == MQTTprefix + "/Set/ColorNormal") {
         int32_t R, G, B;
-        int n = sscanf(payload.c_str(), "%d:%d:%d", &R, &G, &B);
+        int n = sscanf(payload.c_str(), "%d,%d,%d", &R, &G, &B);
 
         // R,G,B is between 0..255
         if (n == 3 && (R >= 0 && R < 256) && (G >= 0 && G < 256) && (B >= 0 && B < 256)) {
@@ -2903,7 +2907,7 @@ void mqtt_receive_callback(const String topic, const String payload) {
         }
     } else if (topic == MQTTprefix + "/Set/ColorSmart") {
         int32_t R, G, B;
-        int n = sscanf(payload.c_str(), "%d:%d:%d", &R, &G, &B);
+        int n = sscanf(payload.c_str(), "%d,%d,%d", &R, &G, &B);
 
         // R,G,B is between 0..255
         if (n == 3 && (R >= 0 && R < 256) && (G >= 0 && G < 256) && (B >= 0 && B < 256)) {
@@ -2913,7 +2917,7 @@ void mqtt_receive_callback(const String topic, const String payload) {
         }
     } else if (topic == MQTTprefix + "/Set/ColorSolar") {
         int32_t R, G, B;
-        int n = sscanf(payload.c_str(), "%d:%d:%d", &R, &G, &B);
+        int n = sscanf(payload.c_str(), "%d,%d,%d", &R, &G, &B);
 
         // R,G,B is between 0..255
         if (n == 3 && (R >= 0 && R < 256) && (G >= 0 && G < 256) && (B >= 0 && B < 256)) {
@@ -2923,7 +2927,7 @@ void mqtt_receive_callback(const String topic, const String payload) {
         }
     } else if (topic == MQTTprefix + "/Set/ColorCustom") {
         int32_t R, G, B;
-        int n = sscanf(payload.c_str(), "%d:%d:%d", &R, &G, &B);
+        int n = sscanf(payload.c_str(), "%d,%d,%d", &R, &G, &B);
 
         // R,G,B is between 0..255
         if (n == 3 && (R >= 0 && R < 256) && (G >= 0 && G < 256) && (B >= 0 && B < 256)) {

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -880,7 +880,7 @@ const char * getMenuItemOption(uint8_t nav) {
     const static char StrMotor[]   = "Motor";
     const static char StrDisabled[] = "Disabled";
     const static char StrLoadBl[9][9]  = {"Disabled", "Master", "Node 1", "Node 2", "Node 3", "Node 4", "Node 5", "Node 6", "Node 7"};
-    const static char StrSwitch[6][11] = {"Disabled", "Access B", "Access S", "Sma-Sol B", "Sma-Sol S", "Grid Relay"};
+    const static char StrSwitch[8][11] = {"Disabled", "Access B", "Access S", "Sma-Sol B", "Sma-Sol S", "Grid Relay", "Custom B", "Custom S"};
     const static char StrGrid[2][10] = {"4Wire", "3Wire"};
     const static char StrEnabled[] = "Enabled";
     const static char StrExitMenu[] = "MENU";

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,8 @@ SWITCH  Set the function of an external switch (pin SW or connector P2)
   <Sma-Sol B>   A momentary push Button is used to switch between Smart and Solar modes
   <Sma-Sol S>   A toggle switch is used to switch between Smart and Solar modes
   <Grid Relay>  A relay, provided by your energy provider, is connected; when the relay is open, power usage is limited to 4.2kW, as per par 14a of the Energy Industry Act.
+  <Custom B>    A momentary push Button can be used by external integrations
+  <Custom S>    A toggle switch can be used by external integrations
 
 RCMON   RCM14-03 Residual Current Monitor is plugged into connector P1
   <Disabled>    The RCD option is not used


### PR DESCRIPTION
This PR allows you to use the button/switch attached to the SmartEVSE for your own purposes.
When you select switch type as Custom (B/S), pressing the button will only alter a boolean value which is communicated to the API and MQTT (also updatable via de api/mqtt).
When selected/on the led color will change to CustomColor (default blue) to indicate it's selected.

Personal use case:
When not selected my home automation will take control of charging (based on dynamic prices), settings modes or current overrides.
When someone needs to charge NOW, the button can be selected and my home automation will charge full speed.
Each day at midnight I will reset back to unselected and resume control.

Ofcourse other use cases are permittable :)

There are also some minor fixes/additions on the custom colors (mqtt annouce, smart color used normal color, mqtt set/get not consistent).