### PR TITLE
OCPP fixes (rebased)

### DIFF
--- a/SmartEVSE-3/platformio.ini
+++ b/SmartEVSE-3/platformio.ini
@@ -32,7 +32,7 @@ lib_deps =
     miq19/eModbus@1.7.2
     bblanchon/ArduinoJson@^6.21.4
     https://github.com/matth-x/MicroOcpp#fb6a765b1ac8240e060f2e65ef0f3022aaafa73f
-    https://github.com/matth-x/MicroOcppMongoose#e0a6ab3bfb7f480798f3258d19d20ae70c41d529
+    https://github.com/matth-x/MicroOcppMongoose#fb1292ed84fbab18c965a131f8704b61ced0f1b7
 build_flags =
     -DENABLE_OCPP=1
     -DCORE_DEBUG_LEVEL=0
@@ -43,7 +43,7 @@ build_flags =
     -D MO_CUSTOM_WS
     -D MO_PARTITION_LABEL='"spiffs"' # Use partition "spiffs" for local data
     -D MO_TRAFFIC_OUT
-    -D MO_MG_USE_VERSION=MO_MG_V714
+    -D MO_MG_USE_VERSION=MO_MG_V715
     -D MO_ENABLE_CONNECTOR_LOCK=1
     -D MO_ENABLE_MBEDTLS=1
     -I ${PROJECT_INCLUDE_DIR} # Make mongoose.h visible for MO-Mongoose

--- a/SmartEVSE-3/platformio.ini
+++ b/SmartEVSE-3/platformio.ini
@@ -31,7 +31,7 @@ extra_scripts = pre:packfs.py
 lib_deps =
     miq19/eModbus@1.7.2
     bblanchon/ArduinoJson@^6.21.4
-    https://github.com/matth-x/MicroOcpp#fb6a765b1ac8240e060f2e65ef0f3022aaafa73f
+    https://github.com/matth-x/MicroOcpp#942fb88aa736a5f99d1a24c11fe657c49af2c7ea
     https://github.com/matth-x/MicroOcppMongoose#fb1292ed84fbab18c965a131f8704b61ced0f1b7
 build_flags =
     -DENABLE_OCPP=1

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -662,9 +662,7 @@ void GLCD(void) {
                         case ChargePointStatus_Charging:
                         case ChargePointStatus_SuspendedEVSE:
                         case ChargePointStatus_SuspendedEV:
-                            // Should not be reached (Access_bit or STATE_C above prevail)
-                            GLCD_print_buf2(2, (const char *) "CHARGING");
-                            GLCD_print_buf2(4, (const char *) "IN PROGRESS");
+                            // Should not be reached (Access_bit or STATE_C above prevail). Do not update the display but keep previous text
                             break;
                         case ChargePointStatus_Finishing:
                             if (ocppLockingTxDefined()) {

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -5116,7 +5116,7 @@ void setup() {
     xTaskCreate(
         BlinkLed,       // Function that should be called
         "BlinkLed",     // Name of the task (for debugging)
-        1024,           // Stack size (bytes)                              // printf needs atleast 1kb
+        2048,           // Stack size (bytes)                              // printf needs atleast 1kb
         NULL,           // Parameter to pass
         1,              // Task priority - low
         NULL            // Task handle

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -4912,14 +4912,22 @@ void ocppLoop() {
             // Access_bit has been set
             OcppTrackAccessBit = true;
             _LOG_A("OCPP detected Access_bit set\n");
-            char buf[13];
-            sprintf(buf, "%02X%02X%02X%02X%02X%02X", RFID[1], RFID[2], RFID[3], RFID[4], RFID[5], RFID[6]);
+            char buf[15];
+            if (RFID[0] == 0x01) {  // old reader 6 byte UID starts at RFID[1]
+                sprintf(buf, "%02X%02X%02X%02X%02X%02X", RFID[1], RFID[2], RFID[3], RFID[4], RFID[5], RFID[6]);
+            } else {
+                sprintf(buf, "%02X%02X%02X%02X%02X%02X%02X", RFID[0], RFID[1], RFID[2], RFID[3], RFID[4], RFID[5], RFID[6]);
+            }
             beginTransaction_authorized(buf);
         } else if (!Access_bit && (OcppTrackAccessBit || (getTransaction() && getTransaction()->isActive()))) {
             OcppTrackAccessBit = false;
             _LOG_A("OCPP detected Access_bit unset\n");
-            char buf[13];
-            sprintf(buf, "%02X%02X%02X%02X%02X%02X", RFID[1], RFID[2], RFID[3], RFID[4], RFID[5], RFID[6]);
+            char buf[15];
+            if (RFID[0] == 0x01) {  // old reader 6 byte UID starts at RFID[1]
+                sprintf(buf, "%02X%02X%02X%02X%02X%02X", RFID[1], RFID[2], RFID[3], RFID[4], RFID[5], RFID[6]);
+            } else {
+                sprintf(buf, "%02X%02X%02X%02X%02X%02X%02X", RFID[0], RFID[1], RFID[2], RFID[3], RFID[4], RFID[5], RFID[6]);
+            }
             endTransaction_authorized(buf);
         }
     }


### PR DESCRIPTION
This PR addresses issues which were discovered during the latest Plugfest (thanks again @dingo35 for testing!) and contains two changes which I would consider important for the final OCPP release. Unfortunately, I don't have access to my SmartEVSE right now, so I still need to validate these which I will do as soon as possible then.

Fixes:

- The WS Basic Auth key handler was broken in the latest version of MO-Mongoose. I fixed it in MO-Mongoose (https://github.com/matth-x/MicroOcppMongoose/pull/15) and pulled in the latest change here (a77d83c16ceeb1a3f66bb45202cc552ebd0176a2)
- The handling of 6- and 7-digit RFID UUIDs is inconsistent. In operational mode EnableAll /-One, the OCPP integration always assumed 6-digit UUIDs, but in RmtOcpp mode, it distinguished according to the first mode byte. 3eb921e454415d50f325ea32274891e0be49edca hopefully closes the gap by adding a further distinction
- When stopping a transaction, the display shows "Charging in progress" for a short moment which looks like a glitch (and is, actually). 406aa82dc0d5438dcc05931bfc3dd392a082a8a3 removes that message

Changes for Release:

- Upgrade to the latest MO version (899eb62ac79fe4919f0062517f90bceee28a4d06)
- ~Move all OCPP files into a dedicated folder. This increases the performance of the MO transaction store after it has been rewritten to crawling the base folder instead of building an index structure. This breaks existing deployments with OCPP, but I think now is the last chance for this before the official release~ (**Update:** needs to be fixed for LittleFS)

Supersedes #134 