### PR TITLE
network.cpp: remove excessive uptime & rssi updates

### DIFF
--- a/SmartEVSE-3/src/network.cpp
+++ b/SmartEVSE-3/src/network.cpp
@@ -1375,10 +1375,6 @@ void network_loop() {
         if (!LocalTimeSet && WIFImode == 1) {
             _LOG_A("Time not synced with NTP yet.\n");
         }
-#if MQTT
-        MQTTclient.publish(MQTTprefix + "/ESPUptime", esp_timer_get_time() / 1000000, false, 0);
-        MQTTclient.publish(MQTTprefix + "/WiFiRSSI", String(WiFi.RSSI()), false, 0);
-#endif
     }
 
     mg_mgr_poll(&mgr, 100);                                                     // TODO increase this parameter to up to 1000 to make loop() less greedy


### PR DESCRIPTION
Fixes #149 

The current code updates the MQTT WiFiRSSI and uptime sensors very often, as there is an update logic in the network loop. This logic is a duplication of the normal MQTT data update, so it is safe to remove (no data will be lost, it will just be updated less frequently which is desired).

I just went ahead and drafted the PR, as the change is simple.

deeplink to the existing, remaining update logic (see lines 3208 and 3227)

https://github.com/dingo35/SmartEVSE-3.5/blob/5892adc3fccd7ce61b5a998e1081555ef379d564/SmartEVSE-3/src/main.cpp#L3195-L3257