### PR TITLE
Invert power measurement when receiving currents for Inverted Eastron

### DIFF
--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -820,7 +820,7 @@ void GLCD(void) {
                                                                                 // If current flow is < 0.3A don't show the blob
 
         if (EVMeter.Type) {                                                     // If we have a EV kWh meter configured, Show total charged energy in kWh on LCD.
-            sprintfl(Str, "%2u.%1ukWh", EVMeter.EnergyCharged, 3, 1);           // Will reset to 0.0kWh when charging cable reconnected, and state change from STATE B->C
+            sprintfl(Str, "%2d.%1dkWh", EVMeter.EnergyCharged, 3, 1);           // Will reset to 0.0kWh when charging cable reconnected, and state change from STATE B->C
             GLCD_write_buf_str(89, 1, Str,GLCD_ALIGN_LEFT);                     // print to buffer
         }
 
@@ -843,9 +843,9 @@ void GLCD(void) {
 
             if (LCDToggle && EVMeter.Type) {
                 if (EVMeter.PowerMeasured < 9950) {
-                    sprintfl(Str, "%1u.%1ukW", EVMeter.PowerMeasured, 3, 1);
+                    sprintfl(Str, "%1d.%1dkW", EVMeter.PowerMeasured, 3, 1);
                 } else {
-                    sprintfl(Str, "%ukW", EVMeter.PowerMeasured, 3, 0);
+                    sprintfl(Str, "%dkW", EVMeter.PowerMeasured, 3, 0);
                 }
             } else {
                 sprintfl(Str, "%uA", Balanced[0], 1, 0);
@@ -922,14 +922,14 @@ void GLCD(void) {
                     break;
                 case 3:
                     if (EVMeter.Type) {
-                        sprintfl(Str, "%u.%01u kW", EVMeter.PowerMeasured, 3, 1);
+                        sprintfl(Str, "%d.%01d kW", EVMeter.PowerMeasured, 3, 1);
                         GLCD_print_buf2(5, Str);
                         break;
                     } else LCDText++;
                     // fall through
                 case 4:
                     if (EVMeter.Type) {
-                        sprintfl(Str, "%u.%02u kWh", EVMeter.EnergyCharged, 3, 2);
+                        sprintfl(Str, "%d.%02d kWh", EVMeter.EnergyCharged, 3, 2);
                         GLCD_print_buf2(5, Str);
                         break;
                     } else LCDText++;

--- a/SmartEVSE-3/src/meter.cpp
+++ b/SmartEVSE-3/src/meter.cpp
@@ -260,11 +260,7 @@ uint8_t Meter::receiveCurrentMeasurement(uint8_t *buf) {
         for (x = 0; x < 3; x++) {
             Power[x] = decodeMeasurement(buf, x + offset, EMConfig[Type].PDivisor);
             PowerMeasured += Power[x];
-            if (Type != EM_EASTRON3P_INV) {
-                if (Power[x] < 0) var[x] = -var[x];
-            } else {
-                if (Power[x] > 0) var[x] = -var[x];
-            }
+            if (Power[x] < 0) var[x] = -var[x];
         }
     }
 

--- a/SmartEVSE-3/src/meter.cpp
+++ b/SmartEVSE-3/src/meter.cpp
@@ -259,6 +259,7 @@ uint8_t Meter::receiveCurrentMeasurement(uint8_t *buf) {
         PowerMeasured = 0;                                                      // so we calculate PowerMeasured so we dont have to poll for this again
         for (x = 0; x < 3; x++) {
             Power[x] = decodeMeasurement(buf, x + offset, EMConfig[Type].PDivisor);
+            if(Type == EM_EASTRON3P_INV) Power[x] = -Power[x];
             PowerMeasured += Power[x];
             if (Power[x] < 0) var[x] = -var[x];
         }


### PR DESCRIPTION
Fixes #145 
Fixes #146 

When receiving currents for some meters, SmartEVSE also calculates the power measurement. This power measurement was not properly inverted for Inverted Eastron meters, causing a negative power readout.

Before (Firmware 3.7.2)
![image](https://github.com/user-attachments/assets/8863853d-61e6-455b-86e5-13254128dce2)

After this change:
![image](https://github.com/user-attachments/assets/b65e29f4-b672-4219-8cd6-03ff140daeb6)

Currents are also still measured correctly after this change.

I verified this with an Eastron SDM630-Modbus V2.
