### PR TITLE
Restrict error counter

### DIFF
--- a/integrations/slimmelezer/sl32.yaml
+++ b/integrations/slimmelezer/sl32.yaml
@@ -280,4 +280,6 @@ interval:
                 on_error:
                   then:
                     lambda: |-
-                      id(smartevse_error) += 1;
+                      if (id(smartevse_error) < 5) {
+                        id(smartevse_error) += 1;
+                      }


### PR DESCRIPTION
To avoid a potential integer overflow I made increasing the error count conditional.