### PR TITLE
MG_TLS_BUILTIN - Mongoose's embedded TLS 1.3 stack - Super fast!

### DIFF
--- a/SmartEVSE-3/platformio.ini
+++ b/SmartEVSE-3/platformio.ini
@@ -38,7 +38,7 @@ build_flags =
     -DCORE_DEBUG_LEVEL=0
     -DLOG_LEVEL=0
     -DMG_ENABLE_PACKED_FS=1
-    -DMG_TLS=MG_TLS_MBED
+    -DMG_TLS=MG_TLS_BUILTIN
     -DMG_ARCH=MG_ARCH_ESP32
     -D MO_CUSTOM_WS
     -D MO_PARTITION_LABEL='"spiffs"' # Use partition "spiffs" for local data


### PR DESCRIPTION
While debugging performance issues related to slow and occasionally failing HTTPS requests, I discovered that this project was still using the legacy MG_TLS_MBED setting in Mongoose.

This setting is now considered deprecated. The recommended and modern approach is to use MG_TLS_BUILTIN, which leverages Mongoose’s built-in TLS 1.3 stack. 

After switching to MG_TLS_BUILTIN, I observed a significant improvement in connection speed and stability. Although I haven't benchmarked it formally, the responsiveness feels at least 10x better. ;-)

This change should help reduce connection timeouts and improve the overall reliability of HTTPS!

Also the bundled certificate is expired.