### PR TITLE
Changed the scan time and timeouts of the HomeWizard P1 integrations.

### DIFF
--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -2840,12 +2840,12 @@ bool fwNeedsUpdate(char * version) {
   * Periodically retrieves current measurements from the HomeWizard P1 energy meter
   * and updates the main meter's currents.
   *
-  * This function ensures a delay of at least 5 seconds between consecutive data retrieval attempts.
+  * This function ensures a delay of at least 1.95 seconds between consecutive data retrieval attempts.
   */
-void homewizard_loop() {
+ void homewizard_loop() {
     static unsigned long lastCheck_homewizard = 0;
 
-    constexpr unsigned long interval = 4000; // 4 seconds
+    constexpr unsigned long interval = 1950; // 1.95 seconds - With this setting there can be 5 attempts for updating the data before the 10 second Mains Meter timeout.
     const unsigned long currentTime = millis();
 
     if (currentTime - lastCheck_homewizard < interval) {

--- a/SmartEVSE-3/src/network.cpp
+++ b/SmartEVSE-3/src/network.cpp
@@ -822,7 +822,7 @@ std::pair<int8_t, std::array<std::int8_t, 3> > getMainsFromHomeWizardP1() {
 
     if (!homeWizardHttpClientInitialized) {
         homeWizardHttpClient = new HTTPClient();
-        homeWizardHttpClient->setTimeout(3500);
+        homeWizardHttpClient->setTimeout(1500);
         homeWizardHttpClient->addHeader("User-Agent", "SmartEVSE-v3");
         homeWizardHttpClient->addHeader("Accept", "application/json");
         homeWizardHttpClientInitialized = true;


### PR DESCRIPTION
It will now scan more frequently so it can do 5 scans withing the 10 seconds Mains Meter timeout.

This wil make it more robust against WiFi timeouts and failed requests.