### PR TITLE
CableLock

### DIFF
--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -266,6 +266,21 @@
               document.getElementById("lcdlock_label").classList.add("ui-checkbox-off")
             }            
 
+            if (data.evse.lock != 0) {
+              if (data.settings.cablelock == 1) {
+                  document.getElementById("cablelock").checked = true;
+                  document.getElementById("cablelock_label").classList.remove("ui-checkbox-off")
+                  document.getElementById("cablelock_label").classList.add("ui-checkbox-on")
+              } else {
+                  document.getElementById("cablelock").checked = false;
+                  document.getElementById("cablelock_label").classList.remove("ui-checkbox-on")
+                  document.getElementById("cablelock_label").classList.add("ui-checkbox-off")
+              }
+            } else {
+              $('[id=cablelock]').hide();
+              $('[id=cablelock_label]').hide();
+            }
+
             if (data.ocpp) {
               if (data.ocpp.mode == "Enabled") {
                 $('[id=ocpp_settings]').show();
@@ -1044,6 +1059,10 @@
                       var LCDlockCheckbox = document.getElementById("lcdlock");
                       $.post( "/settings?lcdlock=" + (LCDlockCheckbox.checked == true ? 1 : 0));
                     }
+                    function toggleCableLock() {
+                      var CableLockCheckbox = document.getElementById("cablelock");
+                      $.post( "/settings?cablelock=" + (CableLockCheckbox.checked == true ? 1 : 0));
+                    }
                     function toggleEnableOcpp() {
                       var enableOcppCheckbox = document.getElementById("enable_ocpp");
                       $.post( "/settings?ocpp_update=1&ocpp_mode=" + (enableOcppCheckbox.checked == true ? 1 : 0));
@@ -1195,13 +1214,15 @@
                                     </div>
                                     <div class="row no-gutters align-items-center">
                                       <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
-                                        LCD:
+                                        Lock:
                                       </div>
                                       <div class="col">
                                           <input type="checkbox" class="form-check-input" id="lcdlock" onclick="toggleLCDlock()">
                                           <label class="form-check-label" style="width: 140px; display:inline-block;" for="lcdlock" id="lcdlock_label" title="Lock buttons on LCD screen">LCD Lock</label>
-                                        </div>
-                                    </div>  
+                                          <input type="checkbox" class="form-check-input" id="cablelock" onclick="toggleCableLock()">
+                                          <label class="form-check-label" style="width: 155px; display:inline-block;" for="cablelock" id="cablelock_label" title="Lock cable with actuator on EVSE side">Cable Lock</label>
+                                      </div>
+                                    </div> 
                                     <div class="row no-gutters align-items-center with_modem">
                                         <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                             Override PWM:

--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -266,7 +266,7 @@
               document.getElementById("lcdlock_label").classList.add("ui-checkbox-off")
             }            
 
-            if (data.evse.lock != 0) {
+            if (data.settings.lock != 0) {
               if (data.settings.cablelock == 1) {
                   document.getElementById("cablelock").checked = true;
                   document.getElementById("cablelock_label").classList.remove("ui-checkbox-off")
@@ -1217,10 +1217,12 @@
                                         Lock:
                                       </div>
                                       <div class="col">
-                                          <input type="checkbox" class="form-check-input" id="lcdlock" onclick="toggleLCDlock()">
-                                          <label class="form-check-label" style="width: 140px; display:inline-block;" for="lcdlock" id="lcdlock_label" title="Lock buttons on LCD screen">LCD Lock</label>
-                                          <input type="checkbox" class="form-check-input" id="cablelock" onclick="toggleCableLock()">
-                                          <label class="form-check-label" style="width: 155px; display:inline-block;" for="cablelock" id="cablelock_label" title="Lock cable with actuator on EVSE side">Cable Lock</label>
+                                          <div class="lock-options">
+                                              <input type="checkbox" class="form-check-input" id="lcdlock" onclick="toggleLCDlock()">
+                                              <label class="form-check-label" style="width: 140px; display:inline-block;" for="lcdlock" id="lcdlock_label" title="Lock buttons on LCD screen">LCD Lock</label>
+                                              <input type="checkbox" class="form-check-input" id="cablelock" onclick="toggleCableLock()">
+                                              <label class="form-check-label" style="width: 155px; display:inline-block;" for="cablelock" id="cablelock_label" title="Lock cable with actuator on EVSE side">Cable Lock</label>
+                                          </div>
                                       </div>
                                     </div> 
                                     <div class="row no-gutters align-items-center with_modem">

--- a/SmartEVSE-3/data/styling.css
+++ b/SmartEVSE-3/data/styling.css
@@ -73,3 +73,9 @@
 #lcd .lcd-activate:hover {
     opacity: 1;
 }
+
+.lock-options {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -181,6 +181,7 @@ extern uint16_t ImportCurrent;
 extern struct DelayedTimeStruct DelayedStopTime;
 extern uint8_t DelayedRepeat;
 extern uint8_t LCDlock;
+extern uint8_t Lock;
 extern uint8_t CableLock;
 extern EnableC2_t EnableC2;
 extern uint8_t RFIDReader;
@@ -999,6 +1000,7 @@ void read_settings() {
         DelayedStopTime.epoch2 = preferences.getULong("DelayedStopTime", DELAYEDSTOPTIME);    //epoch2 is 4 bytes long on arduino
         DelayedRepeat = preferences.getUShort("DelayedRepeat", 0);
         LCDlock = preferences.getUChar("LCDlock", LCD_LOCK);
+        Lock = preferences.getUChar("Lock", LOCK);
         CableLock = preferences.getUChar("CableLock", CABLE_LOCK);
         LCDPin = preferences.getUShort("LCDPin", 0);
         AutoUpdate = preferences.getUChar("AutoUpdate", AUTOUPDATE);
@@ -1234,6 +1236,7 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
         doc["settings"]["stoptime"] = (DelayedStopTime.epoch2 ? DelayedStopTime.epoch2 + EPOCH2_OFFSET : 0);
         doc["settings"]["repeat"] = DelayedRepeat;
         doc["settings"]["lcdlock"] = LCDlock;
+        doc["settings"]["lock"] = Lock;
         doc["settings"]["cablelock"] = CableLock;
 #if MODEM
             doc["settings"]["required_evccid"] = RequiredEVCCID;

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -1000,7 +1000,6 @@ void read_settings() {
         DelayedStopTime.epoch2 = preferences.getULong("DelayedStopTime", DELAYEDSTOPTIME);    //epoch2 is 4 bytes long on arduino
         DelayedRepeat = preferences.getUShort("DelayedRepeat", 0);
         LCDlock = preferences.getUChar("LCDlock", LCD_LOCK);
-        Lock = preferences.getUChar("Lock", LOCK);
         CableLock = preferences.getUChar("CableLock", CABLE_LOCK);
         LCDPin = preferences.getUShort("LCDPin", 0);
         AutoUpdate = preferences.getUChar("AutoUpdate", AUTOUPDATE);

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -177,6 +177,7 @@ extern uint16_t ImportCurrent;
 extern struct DelayedTimeStruct DelayedStopTime;
 extern uint8_t DelayedRepeat;
 extern uint8_t LCDlock;
+extern uint8_t CableLock;
 extern EnableC2_t EnableC2;
 extern uint8_t RFIDReader;
 
@@ -723,6 +724,12 @@ void mqtt_receive_callback(const String topic, const String payload) {
             ColorCustom[1] = G;
             ColorCustom[2] = B;
         }
+    } else if (topic == MQTTprefix + "/Set/CableLock") {
+        if (payload == "1") {
+            CableLock = 1;
+        } else {
+            CableLock = 0;
+        }
     }
 
     // Make sure MQTT updates directly to prevent debounces
@@ -876,6 +883,11 @@ void SetupMQTTClient() {
     optional_payload = jsna("command_topic", String(MQTTprefix + "/Set/CurrentOverride")) + jsna("min", "0") + jsna("max", MaxCurrent ) + jsna("mode","slider");
     optional_payload += jsna("value_template", R"({{ value | int / 10 if value | is_number else none }})") + jsna("command_template", R"({{ value | int * 10 }})");
     announce("Charge Current Override", "number");
+
+    //set the parameters for and announce Cable Lock:
+    optional_payload = jsna("cablelock_topic", String(MQTTprefix + "/CableLock")) + jsna("command_topic", String(MQTTprefix + "/Set/CableLock"));
+    optional_payload += String(R"(, "options" : ["0", "1"])");
+    announce("Cable Lock", "select");
 }
 
 void mqttPublishData() {
@@ -938,6 +950,9 @@ void mqttPublishData() {
         MQTTclient.publish(MQTTprefix + "/LEDColorSmart", String(ColorSmart[0])+","+String(ColorSmart[1])+","+String(ColorSmart[2]), true, 0);
         MQTTclient.publish(MQTTprefix + "/LEDColorSolar", String(ColorSolar[0])+","+String(ColorSolar[1])+","+String(ColorSolar[2]), true, 0);
         MQTTclient.publish(MQTTprefix + "/LEDColorCustom", String(ColorCustom[0])+","+String(ColorCustom[1])+","+String(ColorCustom[2]), true, 0);
+        if (Lock != 0) {
+            MQTTclient.publish(MQTTprefix + "/CableLock", CableLock ? "Enabled" : "Disabled", true, 0);
+        }
 }
 #endif
 
@@ -1054,6 +1069,7 @@ void read_settings() {
         DelayedStopTime.epoch2 = preferences.getULong("DelayedStopTime", DELAYEDSTOPTIME);    //epoch2 is 4 bytes long on arduino
         DelayedRepeat = preferences.getUShort("DelayedRepeat", 0);
         LCDlock = preferences.getUChar("LCDlock", LCD_LOCK);
+        CableLock = preferences.getUChar("CableLock", CABLE_LOCK);
         LCDPin = preferences.getUShort("LCDPin", 0);
         AutoUpdate = preferences.getUChar("AutoUpdate", AUTOUPDATE);
 
@@ -1124,6 +1140,7 @@ void write_settings(void) {
     preferences.putUShort("maxTemp", maxTemp);
     preferences.putUChar("AutoUpdate", AutoUpdate);
     preferences.putUChar("LCDlock", LCDlock);
+    preferences.putUChar("CableLock", CableLock);
     preferences.putUShort("LCDPin", LCDPin);
 
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
@@ -1283,6 +1300,7 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
         doc["settings"]["stoptime"] = (DelayedStopTime.epoch2 ? DelayedStopTime.epoch2 + EPOCH2_OFFSET : 0);
         doc["settings"]["repeat"] = DelayedRepeat;
         doc["settings"]["lcdlock"] = LCDlock;
+        doc["settings"]["cablelock"] = CableLock;
 #if MODEM
             doc["settings"]["required_evccid"] = RequiredEVCCID;
             doc["settings"]["modem"] = "Experiment";
@@ -1602,6 +1620,14 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
             if (lock >= 0 && lock <= 1) {                                   //boundary check
                 LCDlock = lock;
                 doc["lcdlock"] = lock;
+            }
+        }
+
+        if(request->hasParam("cablelock")) {
+            int c_lock = request->getParam("cablelock")->value().toInt();
+            if (c_lock >= 0 && c_lock <= 1) {                               //boundary check
+                CableLock = c_lock;
+                doc["cablelock"] = c_lock;
             }
         }
 
@@ -1948,6 +1974,23 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
         String json;
         serializeJson(doc, json);
         mg_http_reply(c, 200, "Content-Type: application/json\r\n", "%s\r\n", json.c_str());
+        return true;
+
+
+    } else if (mg_http_match_uri(hm, "/cablelock") && !memcmp("POST", hm->method.buf, hm->method.len)) {
+        DynamicJsonDocument doc(200);
+
+        if(request->hasParam("1")) {
+            CableLock = 1;
+            doc["cablelock"] = CableLock;
+        } else {
+            CableLock = 0;
+            doc["cablelock"] = CableLock;
+        }
+
+        String json;
+        serializeJson(doc, json);
+        mg_http_reply(c, 200, "Content-Type: application/json\r\n", "%s\r\n", json.c_str());    // Yes. Respond JSON
         return true;
 
 #if MODEM

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -204,6 +204,7 @@ uint16_t SolarStopTimer = 0;
 #ifdef SMARTEVSE_VERSION //ESP32 v3 and v4
 uint8_t DelayedRepeat;                                                      // 0 = no repeat, 1 = daily repeat
 uint8_t LCDlock = LCD_LOCK;                                                 // 0 = LCD buttons operational, 1 = LCD buttons disabled
+uint8_t CableLock = CABLE_LOCK;                                             // 0 = Disabled (default), 1 = Enabled
 uint16_t BacklightTimer = 0;                                                // Backlight timer (sec)
 uint8_t BacklightSet = 0;
 uint8_t LCDTimer = 0;
@@ -2165,23 +2166,25 @@ static unsigned int locktimer = 0, unlocktimer = 0;
     // Check if the cable lock is used
     if (!Config && Lock) {                                      // Socket used and Cable lock enabled?
         // UnlockCable takes precedence over LockCable
-        if ((RFIDReader == 2 && AccessStatus == OFF) ||        // One RFID card can Lock/Unlock the charging socket (like a public charging station)
+        if ((RFIDReader == 2 && AccessStatus == OFF) ||         // One RFID card can Lock/Unlock the charging socket (like a public charging station)
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
         (OcppMode &&!OcppForcesLock) ||
 #endif
             State == STATE_A) {                                 // The charging socket is unlocked when unplugged from the EV
-            if (unlocktimer == 0) {                             // 600ms pulse
-                ACTUATOR_UNLOCK;
-            } else if (unlocktimer == 6) {
-                ACTUATOR_OFF;
+            if (CableLock != 1 && Lock != 0) {                  // CableLock is Enabled, do not unlock
+                if (unlocktimer == 0) {                         // 600ms pulse
+                    ACTUATOR_UNLOCK;
+                } else if (unlocktimer == 6) {
+                    ACTUATOR_OFF;
+                }
+                if (unlocktimer++ > 7) {
+                    if (digitalRead(PIN_LOCK_IN) == (Lock == 2 ? 1:0 ))         // still locked...
+                    {
+                        if (unlocktimer > 50) unlocktimer = 0;      // try to unlock again in 5 seconds
+                    } else unlocktimer = 7;
+                }
+                locktimer = 0;
             }
-            if (unlocktimer++ > 7) {
-                if (digitalRead(PIN_LOCK_IN) == (Lock == 2 ? 1:0 ))         // still locked...
-                {
-                    if (unlocktimer > 50) unlocktimer = 0;      // try to unlock again in 5 seconds
-                } else unlocktimer = 7;
-            }
-            locktimer = 0;
         // Lock Cable    
         } else if (State != STATE_A                            // Lock cable when connected to the EV
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
@@ -2673,7 +2676,7 @@ void Timer10ms_singlerun(void) {
                     setState(STATE_MODEM_REQUEST);
                 else
 #endif
-                    setState(STATE_B);                                          // switch to State B
+                setState(STATE_B);                                          // switch to State B
                 ActivationMode = 30;                                        // Activation mode is triggered if state C is not entered in 30 seconds.
                 AccessTimer = 0;
             } else if (Mode == MODE_SOLAR) {                                // Not enough power:

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -2188,7 +2188,7 @@ static unsigned int locktimer = 0, unlocktimer = 0;
     // Check if the cable lock is used
     if (!Config && Lock) {                                      // Socket used and Cable lock enabled?
         // UnlockCable takes precedence over LockCable
-        if ((RFIDReader == 2 && AccessStatus == OFF) ||         // One RFID card can Lock/Unlock the charging socket (like a public charging station)
+        if ((RFIDReader == 2 && AccessStatus == OFF) ||        // One RFID card can Lock/Unlock the charging socket (like a public charging station)
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
         (OcppMode &&!OcppForcesLock) ||
 #endif
@@ -2832,7 +2832,7 @@ void Timer10ms_singlerun(void) {
                     setState(STATE_MODEM_REQUEST);
                 else
 #endif
-                setState(STATE_B);                                          // switch to State B
+                    setState(STATE_B);                                          // switch to State B
                 ActivationMode = 30;                                        // Activation mode is triggered if state C is not entered in 30 seconds.
                 AccessTimer = 0;
             } else if (Mode == MODE_SOLAR) {                                // Not enough power:

--- a/SmartEVSE-3/src/main.h
+++ b/SmartEVSE-3/src/main.h
@@ -126,6 +126,7 @@
 #define AUTOUPDATE 0                                                            // default for Automatic Firmware Update: 0 = disabled, 1 = enabled
 #define SB2_WIFI_MODE 0
 #define LCD_LOCK 0                                                              // 0 = LCD buttons operational, 1 = LCD buttons disabled
+#define CABLE_LOCK 0                                                            // 0 = Cable Lock disabled, 1 = Cable Lock enabled
 #define INITIALIZED 0
 
 // Mode settings


### PR DESCRIPTION
Add an enhanced cable locking option to the dashboard (making it also available in REST API) and in the "/Set topic" section of the MQTT API. The enhanced cable locking, when activated, will keep the actuator of the EVSE locked, even if no EV is connected. This option will only be available if a locking device (Solenoid or Motor) is enabled in the LCD menu of the EVSE.