### PR TITLE
Add documentation for HomeWizard P1 meter in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,7 @@ Only appears if [MODE](#mode) is **Smart** or **Solar**. Set the type of MAINS k
 - **Sensorbox**: The Sensorbox sends measurement data to the SmartEVSE.
 - **API**: MAINS meter data is fed through the [REST API](REST_API.md) or [MQTT API](#mqtt-api).
 - **Phoenix C** / **Finder** / **...** / **Custom**: A Modbus kWh meter is used.
+- **HmWzrd P1**: HomeWizard P1 meter (wifi based connection to the smart meter's P1 port).
 
 **Note**:  
 - Eastron1P is for single-phase Eastron meters.  


### PR DESCRIPTION
Under MAINS MET added "HmWzrd P1: HomeWizard P1 meter (wifi based connection to the smart meter's P1 port)."