### PR TITLE
meter: add Orno WE-517 support

### DIFF
--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -1244,13 +1244,13 @@ void GLCDMenu(uint8_t Buttons) {
                     case MENU_MAINSMETER:
                         do {
                             value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
-                        } while (value >= EM_UNUSED_SLOT3 && value <= EM_UNUSED_SLOT4);
+                        } while (value >= EM_UNUSED_SLOT4 && value <= EM_UNUSED_SLOT4);
                         setItemValue(LCDNav, value);
                         break;
                     case MENU_EVMETER:                                          // do not display the Sensorbox, HomeWizard P1 or unused slots here
                         do {
                             value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
-                        } while (value == EM_SENSORBOX || value == EM_HOMEWIZARD_P1 || (value >= EM_UNUSED_SLOT3 && value <= EM_UNUSED_SLOT4));
+                        } while (value == EM_SENSORBOX || value == EM_HOMEWIZARD_P1 || (value >= EM_UNUSED_SLOT4 && value <= EM_UNUSED_SLOT4));
                         setItemValue(LCDNav, value);
                         break;
                     case MENU_WIFI:

--- a/SmartEVSE-3/src/meter.cpp
+++ b/SmartEVSE-3/src/meter.cpp
@@ -33,7 +33,7 @@ struct EMstruct EMConfig[] = {
     {"Schneider", ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x0BD3, 0, 0x0BB7, 0, 0x0BF3,-3, 0xB02B, 0,0xB02D, 0}, // Schneider iEM3x5x series (V / A / kW / kWh) iEM3x50 counts only Energy Import, no Export
     {"Chint",     ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x2000, 1, 0x200C, 3, 0x2012, 1, 0x101E, 0,0x1028, 0}, // Chint DTSU666 (0.1V / mA / 0.1W / kWh)
     {"C.Gavazzi", ENDIANESS_HBF_LWF, 4, MB_DATATYPE_INT32,      0x0, 1,    0xC, 3,   0x28, 1,   0x34, 1,  0x4E, 1}, // Carlo Gavazzi EM340 (0.1V / mA / 0.1W / 0.1kWh) 
-    {"Unused 3",  ENDIANESS_LBF_LWF, 4, MB_DATATYPE_INT32,        0, 0,      0, 0,      0, 0,      0, 0,     0, 0}, // unused slot for future new meters
+    {"OrnoWE517", ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32,    0xE, 0,   0x16, 0,   0x1C,-3, 0x108,  0, 0x110, 0}, // Orno WE-517 (V / A / kW / kWh)
     {"Unused 4",  ENDIANESS_LBF_LWF, 4, MB_DATATYPE_INT32,        0, 0,      0, 0,      0, 0,      0, 0,     0, 0}, // unused slot for future new meters
     {"Custom",    ENDIANESS_LBF_LWF, 4, MB_DATATYPE_INT32,        0, 0,      0, 0,      0, 0,      0, 0,     0, 0}  // Last entry!
 };

--- a/SmartEVSE-3/src/meter.h
+++ b/SmartEVSE-3/src/meter.h
@@ -48,7 +48,7 @@
 #define EM_SCHNEIDER 14
 #define EM_CHINT 15
 #define EM_CARLO_CAVAZZI 16
-#define EM_UNUSED_SLOT3 17
+#define EM_ORNO_WE517 17
 #define EM_UNUSED_SLOT4 18
 #define EM_CUSTOM 19
 


### PR DESCRIPTION
Added the cheap and popular Orno WE-517 meter.
There's one additional requirement: reconfiguring the serial port for `even` parity.
I'll add that configuration through the menu system in a separate PR, if you want?