### PR TITLE
Update sl32.yaml

### DIFF
--- a/integrations/slimmelezer/sl32.yaml
+++ b/integrations/slimmelezer/sl32.yaml
@@ -269,7 +269,7 @@ interval:
                           id(signed_current_l2).state * 10,
                           id(signed_current_l3).state * 10);
                   return url;
-                headers:
+                request_headers:
                   Content-Length: 0
                 on_response:
                   then:


### PR DESCRIPTION
In esphome 2025.5.0 the HTTP Request actions have had the `headers` config variable renamed to `request_headers`.