### PR TITLE
Increase modbus timeout

### DIFF
--- a/SmartEVSE-3/src/modbus.cpp
+++ b/SmartEVSE-3/src/modbus.cpp
@@ -859,7 +859,7 @@ void ConfigureModbusMode(uint8_t newmode) {
             if (newmode != 255) MBserver.end();
             _LOG_A("ConfigureModbusMode2 task free ram: %u\n", uxTaskGetStackHighWaterMark( NULL ));
 
-            MBclient.setTimeout(85);                        // Set modbus timeout to 85ms. 15ms lower then modbusRequestloop time of 100ms.
+            MBclient.setTimeout(200);                        // Set modbus timeout to 200ms. Should this be lower than the modbusRequestloop time of 100ms?
             MBclient.onDataHandler(&MBhandleData);
             MBclient.onErrorHandler(&MBhandleError);
             // Start ModbusRTU Master background task


### PR DESCRIPTION
For a new installation I had the challenge of connecting the SensorBox to SmartEVSE which are in 2 unconnected buildings, separated 30m and no option for adding a new cable.

Given that an existing network connection exists between the buildings I opted for a [RS485-Ethernet converter](https://www.pusr.com/products/din-rail-rs485-serial-to-ethernet-converter-usr-dr302.html) on both ends. One configured as a TCP-server, the other as TCP-client. I don't make use of the modbus capabilites of these devices, as this could lead to multiple masters on the same bus. So plain RS485 point-to-point tunneled over TCP.

At first glance, this seems to work without any issue, SmartEVSE reporting the currents of the Sensorbox.
However, after ~11s the error `ERROR NO SERIAL COM CHECK CFG OR WIRING`, which than also cleared after 1-2s. This repeats.

Redoing / checking the wiring and config didn't help.

With the debug firmware I identified that Modbus was having timeout issues, which was configured to be be 85ms.
Looking at the specs of the converter it states that `Average Transmission Delay <10ms`. But this is for a single conversion I assume. So for a full Request-Response cycle, we encounter this delay 4 times.

Configuring the modbus timeout to `95ms` (below the mentioned `100ms`) was not sufficient and the behavior remained the same.
When the timeout was increased to `200ms` all communication errors disappeared and the complete SmartEVSE seems to function properly.

Open question remains: Is there an issue with having `timeout > 100ms modbusRequestloop`? I cannot oversee this impact, however I looks like everything works fine.

If there is no issue, I would like to contribute this change, so other users can use these converters as well. Even willing to add some diagrams / configs how to setup.