### PR TITLE
Added ABB EV3 modbus energy meter

### DIFF
--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -1270,13 +1270,13 @@ void GLCDMenu(uint8_t Buttons) {
                     case MENU_MAINSMETER:
                         do {
                             value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
-                        } while (value >= EM_UNUSED_SLOT3 && value <= EM_UNUSED_SLOT4);
+                        } while ( value == EM_UNUSED_SLOT4);
                         setItemValue(LCDNav, value);
                         break;
                     case MENU_EVMETER:                                          // do not display the Sensorbox, HomeWizard P1 or unused slots here
                         do {
                             value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
-                        } while (value == EM_SENSORBOX || value == EM_HOMEWIZARD_P1 || (value >= EM_UNUSED_SLOT3 && value <= EM_UNUSED_SLOT4));
+                        } while (value == EM_SENSORBOX || value == EM_HOMEWIZARD_P1 || value == EM_UNUSED_SLOT4);
                         setItemValue(LCDNav, value);
                         break;
                     case MENU_WIFI:

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -2070,7 +2070,12 @@ void requestEnergyMeasurement(uint8_t Meter, uint8_t Address, bool Export) {
             // Note:
             // - Sinotimer uses 16-bit values, except for this measurement it uses 32bit int format
             // fallthrough
-        case EM_ABB:
+        case EM_ABB_B23:
+            // Note:
+            // - ABB uses 64bit values for this register (size 2)
+            Count = 2;
+            break;
+         case EM_ABB_EV3:
             // Note:
             // - ABB uses 64bit values for this register (size 2)
             Count = 2;
@@ -2559,7 +2564,7 @@ void ModbusRequestLoop() {
                         case EM_EASTRON1P:
                         case EM_EASTRON3P:
                         case EM_EASTRON3P_INV:
-                        case EM_ABB:
+                        case EM_ABB_B23:
                         case EM_FINDER_7M:
                         case EM_SCHNEIDER:
                             updated = 0;

--- a/SmartEVSE-3/src/meter.cpp
+++ b/SmartEVSE-3/src/meter.cpp
@@ -22,7 +22,7 @@ struct EMstruct EMConfig[] = {
     {"Finder 7E", ENDIANESS_HBF_HWF, 4, MB_DATATYPE_FLOAT32, 0x1000, 0, 0x100E, 0, 0x1026, 0, 0x1106, 3,0x110E, 3}, // Finder 7E.78.8.400.0212 (V / A / W / Wh) max read count 127
     {"Eastron3P", ENDIANESS_HBF_HWF, 4, MB_DATATYPE_FLOAT32,    0x0, 0,    0x6, 0,   0x34, 0,  0x48 , 0,0x4A  , 0}, // Eastron SDM630 (V / A / W / kWh) max read count 80
     {"InvEastrn", ENDIANESS_HBF_HWF, 4, MB_DATATYPE_FLOAT32,    0x0, 0,    0x6, 0,   0x34, 0,  0x48 , 0,0x4A  , 0}, // Since Eastron SDM series are bidirectional, sometimes they are connected upsidedown, so positive current becomes negative etc.; Eastron SDM630 (V / A / W / kWh) max read count 80
-    {"ABB",       ENDIANESS_HBF_HWF, 3, MB_DATATYPE_INT32,   0x5B00, 1, 0x5B0C, 2, 0x5B14, 2, 0x5000, 2,0x5004, 2}, // ABB B23 212-100 (0.1V / 0.01A / 0.01W / 0.01kWh) RS485 wiring reversed / max read count 125
+    {"ABB B23",   ENDIANESS_HBF_HWF, 3, MB_DATATYPE_INT32,   0x5B00, 1, 0x5B0C, 2, 0x5B14, 2, 0x5000, 2,0x5004, 2}, // ABB B23 212-100 (0.1V / 0.01A / 0.01W / 0.01kWh) RS485 wiring reversed / max read count 125
     {"SolarEdge", ENDIANESS_HBF_HWF, 3, MB_DATATYPE_INT16,    40196, 0,  40191, 0,  40206, 0,  40234, 3, 40226, 3}, // SolarEdge SunSpec (0.01V (16bit) / 0.1A (16bit) / 1W  (16bit) / 1 Wh (32bit))
     {"WAGO",      ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x5002, 0, 0x500C, 0, 0x5012,-3, 0x600C, 0,0x6018, 0}, // WAGO 879-30x0 (V / A / kW / kWh)//TODO maar WAGO heeft ook totaal
     {"API",       ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x5002, 0, 0x500C, 0, 0x5012, 3, 0x6000, 0,0x6018, 0}, // WAGO 879-30x0 (V / A / kW / kWh)
@@ -34,6 +34,7 @@ struct EMstruct EMConfig[] = {
     {"Schneider", ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x0BD3, 0, 0x0BB7, 0, 0x0BF3,-3, 0xB02B, 0,0xB02D, 0}, // Schneider iEM3x5x series (V / A / kW / kWh) iEM3x50 counts only Energy Import, no Export
     {"Chint",     ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x2000, 1, 0x200C, 3, 0x2012, 1, 0x101E, 0,0x1028, 0}, // Chint DTSU666 (0.1V / mA / 0.1W / kWh)
     {"C.Gavazzi", ENDIANESS_HBF_LWF, 4, MB_DATATYPE_INT32,      0x0, 1,    0xC, 3,   0x28, 1,   0x34, 1,  0x4E, 1}, // Carlo Gavazzi EM340 (0.1V / mA / 0.1W / 0.1kWh) 
+    {"ABB EV3",   ENDIANESS_HBF_HWF, 3, MB_DATATYPE_INT32,   0x5B00, 1, 0x5B0C, 2, 0x5B14, 2, 0x5000, 4,0x5004, 4}, // ABB EV3 (0.1V / 0.01A / 0.01W / 0.0001kWh) EV3 has higher Energy resolution than B23, so EDivisor is 4 instead of 2 (EV3 is delivered with Even partiy -> Change to None first)
     {"Unused 3",  ENDIANESS_LBF_LWF, 4, MB_DATATYPE_INT32,        0, 0,      0, 0,      0, 0,      0, 0,     0, 0}, // unused slot for future new meters
     {"Unused 4",  ENDIANESS_LBF_LWF, 4, MB_DATATYPE_INT32,        0, 0,      0, 0,      0, 0,      0, 0,     0, 0}, // unused slot for future new meters
     {"Custom",    ENDIANESS_LBF_LWF, 4, MB_DATATYPE_INT32,        0, 0,      0, 0,      0, 0,      0, 0,     0, 0}  // Last entry!
@@ -285,7 +286,7 @@ uint8_t Meter::receiveCurrentMeasurement(ModBus MB) {
         case EM_EASTRON3P_INV:
             offset = 3u;
             break;
-        case EM_ABB:
+        case EM_ABB_B23:
             offset = 5u;
             break;
         case EM_FINDER_7M:
@@ -332,7 +333,12 @@ uint8_t Meter::receiveCurrentMeasurement(ModBus MB) {
  */
 signed int Meter::receiveEnergyMeasurement(uint8_t *buf) {
     switch (Type) {
-        case EM_ABB:
+        case EM_ABB_B23:
+            // Note:
+            // - ABB uses 32-bit values, except for this measurement it uses 64bit unsigned int format
+            // We skip the first 4 bytes (effectivaly creating uint 32). Will work as long as the value does not exeed  roughly 20 million
+            return decodeMeasurement(buf, 1, EMConfig[Type].Endianness, MB_DATATYPE_INT32, EMConfig[Type].EDivisor-3);
+        case EM_ABB_EV3:
             // Note:
             // - ABB uses 32-bit values, except for this measurement it uses 64bit unsigned int format
             // We skip the first 4 bytes (effectivaly creating uint 32). Will work as long as the value does not exeed  roughly 20 million

--- a/SmartEVSE-3/src/meter.h
+++ b/SmartEVSE-3/src/meter.h
@@ -37,7 +37,7 @@
 #define EM_FINDER_7E 3
 #define EM_EASTRON3P 4
 #define EM_EASTRON3P_INV 5
-#define EM_ABB 6
+#define EM_ABB_B23 6
 #define EM_SOLAREDGE 7
 #define EM_WAGO 8
 #define EM_API 9
@@ -48,7 +48,7 @@
 #define EM_SCHNEIDER 14
 #define EM_CHINT 15
 #define EM_CARLO_CAVAZZI 16
-#define EM_UNUSED_SLOT3 17
+#define EM_ABB_EV3 17
 #define EM_UNUSED_SLOT4 18
 #define EM_CUSTOM 19
 

--- a/SmartEVSE-3/src/modbus.cpp
+++ b/SmartEVSE-3/src/modbus.cpp
@@ -502,7 +502,7 @@ void requestCurrentMeasurement(uint8_t Meter, uint8_t Address) {
             // Phase 1-3 power:   Register 0x0C - 0x11 (signed)
             ModbusReadInputRequest(Address, 4, 0x06, 12);
             break;
-        case EM_ABB:
+        case EM_ABB_B23:
             // Phase 1-3 current: Register 0x5B0C - 0x5B11 (unsigned)
             // Phase 1-3 power:   Register 0x5B16 - 0x5B1B (signed)
             ModbusReadInputRequest(Address, 3, 0x5B0C, 16);


### PR DESCRIPTION
Added ABB EV3 modbus energy meter. Inserted into empty slot EM_UNUSED_SLOT3.
Renamed ABB to ABB B23 to distinguish between the meters. The EV3 has larger imported and exported energy resolution 0.0001 kWh instead of 0.01 kWh. All functions have been fully tested.

Note that ABB EV3 is factory configured with Even parity. First change to parity None before connecting to SmartEVSE.
I also noted that setting the address using the buttons on the EV3 device works for addresses between 0-9. For addresses larger than 9 it does not work (possibly bug in EV3 software). A work around is to change the address by writing it to the register (0x8900) that controls the device address..
