### PR TITLE
EtherLCD support: Ethernet add-on board that replaces the LCD board

### DIFF
--- a/SmartEVSE-3/src/ch390.cpp
+++ b/SmartEVSE-3/src/ch390.cpp
@@ -808,6 +808,8 @@ bool ch390_detect(void) {
     dev.address_bits = 7;
     dev.mode = 3;  // CPOL=1, CPHA=1 (mode 3)
     dev.clock_speed_hz = 1000000; // 1 MHz for safe probing
+    dev.cs_ena_pretrans = 1;      // 62ns CS settling through Pi filter
+    dev.input_delay_ns = 10;      // Compensate for round-trip through Pi filter
     dev.spics_io_num = CH390_CS;
     dev.queue_size = 1;
     dev.flags = SPI_DEVICE_HALFDUPLEX;  // CH390D uses separate read/write phases
@@ -832,9 +834,9 @@ bool ch390_detect(void) {
         pid_h == CH390_PID_H && pid_l == CH390_PID_L) {
         _LOG_I("CH390D detected!\n");
 
-        // Increase SPI clock to 10 MHz for normal operation
+        // Increase SPI clock to 12 MHz for normal operation
         spi_bus_remove_device(s_spi);
-        dev.clock_speed_hz = 10000000;
+        dev.clock_speed_hz = 12000000;
         spi_bus_add_device(s_spi_host, &dev, &s_spi);
 
         EthPresent = true;

--- a/SmartEVSE-3/src/ch390.cpp
+++ b/SmartEVSE-3/src/ch390.cpp
@@ -1,0 +1,1012 @@
+/*
+ * CH390D SPI Ethernet MAC/PHY driver for ESP-IDF 4.4 (Arduino ESP32 2.x)
+ *
+ * Implements esp_eth_mac_t and esp_eth_phy_t interfaces for the CH390D chip.
+ * Uses DMA for rx/tx data transfer, and supports interrupt-driven packet reception.
+ */
+
+#include <Arduino.h>
+
+#if SMARTEVSE_VERSION >= 30 && SMARTEVSE_VERSION < 40
+
+#include "ch390.h"
+#include "network_common.h"
+#include <string.h>
+#include "esp_eth.h"
+#include "esp_eth_mac.h"
+#include "esp_eth_phy.h"
+#include "esp_eth_netif_glue.h"
+#include "esp_event.h"
+#include "esp_netif.h"
+#include "esp_mac.h"
+#include "driver/spi_master.h"
+#include "driver/gpio.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+#include "esp_timer.h"
+#include "esp_rom_sys.h"
+
+// ---------- Runtime state ----------
+bool EthPresent  = false;
+bool EthConnected = false;
+bool EthHasIP    = false;
+
+static spi_device_handle_t s_spi = NULL;
+static spi_host_device_t   s_spi_host = SPI3_HOST; // VSPI
+static esp_netif_t *s_eth_netif = NULL;
+static esp_eth_handle_t s_eth_handle = NULL;
+
+// ---------- Low-level SPI register access ----------
+
+static esp_err_t ch390_reg_read(uint8_t reg, uint8_t *val) {
+    spi_transaction_t t = {};
+    t.cmd = CH390_SPI_RD;
+    t.addr = reg;
+    t.flags = SPI_TRANS_USE_RXDATA;
+    t.rxlength = 8;
+    t.length = 0;
+    esp_err_t ret = spi_device_polling_transmit(s_spi, &t);
+    if (ret == ESP_OK) *val = t.rx_data[0];
+    return ret;
+}
+
+static esp_err_t ch390_reg_write(uint8_t reg, uint8_t val) {
+    spi_transaction_t t = {};
+    t.cmd = CH390_SPI_WR;
+    t.addr = reg;
+    t.flags = SPI_TRANS_USE_TXDATA;
+    t.length = 8;
+    t.tx_data[0] = val;
+    return spi_device_polling_transmit(s_spi, &t);
+}
+
+static esp_err_t ch390_mem_read(uint8_t *buf, uint32_t len) {
+    spi_transaction_t t = {};
+    t.cmd = CH390_SPI_RD;
+    t.addr = CH390_MRCMD;
+    t.rx_buffer = buf;
+    t.rxlength = len * 8;
+    t.length = 0;
+    return spi_device_polling_transmit(s_spi, &t);
+}
+
+static esp_err_t ch390_mem_write(const uint8_t *buf, uint32_t len) {
+    spi_transaction_t t = {};
+    t.cmd = CH390_SPI_WR;
+    t.addr = CH390_MWCMD;
+    t.tx_buffer = buf;
+    t.length = len * 8;
+    return spi_device_polling_transmit(s_spi, &t);
+}
+
+// ---------- Internal PHY register access ----------
+
+static esp_err_t ch390_phy_reg_read(uint8_t phy_reg, uint16_t *val) {
+    ch390_reg_write(CH390_EPAR, CH390_PHY | phy_reg);
+    ch390_reg_write(CH390_EPCR, EPCR_EPOS | EPCR_ERPRR);
+    // Poll EPCR busy flag until hardware signals completion
+    uint8_t epcr;
+    uint32_t to = 0;
+    do {
+        esp_rom_delay_us(100);
+        ch390_reg_read(CH390_EPCR, &epcr);
+        to += 100;
+    } while ((epcr & EPCR_ERRE) && to < 1000);
+    ch390_reg_write(CH390_EPCR, 0);
+    uint8_t lo, hi;
+    ch390_reg_read(CH390_EPDRH, &hi);
+    ch390_reg_read(CH390_EPDRL, &lo);
+    *val = (hi << 8) | lo;
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_reg_write(uint8_t phy_reg, uint16_t val) {
+    ch390_reg_write(CH390_EPAR, CH390_PHY | phy_reg);
+    ch390_reg_write(CH390_EPDRL, val & 0xFF);
+    ch390_reg_write(CH390_EPDRH, (val >> 8) & 0xFF);
+    ch390_reg_write(CH390_EPCR, EPCR_EPOS | EPCR_ERPRW);
+    // Poll EPCR busy flag until hardware signals completion
+    uint8_t epcr;
+    uint32_t to = 0;
+    do {
+        esp_rom_delay_us(100);
+        ch390_reg_read(CH390_EPCR, &epcr);
+        to += 100;
+    } while ((epcr & EPCR_ERRE) && to < 1000);
+    ch390_reg_write(CH390_EPCR, 0);
+    return ESP_OK;
+}
+
+// =====================================================================
+// MAC driver (esp_eth_mac_t implementation)
+// =====================================================================
+
+typedef struct {
+    esp_eth_mac_t parent;
+    esp_eth_mediator_t *eth;
+    TaskHandle_t rx_task;
+    SemaphoreHandle_t spi_lock;
+    uint8_t addr[6];
+    bool flow_ctrl_enabled;
+    uint8_t *rx_buffer;
+} emac_ch390_t;
+
+static emac_ch390_t *s_emac = NULL;
+static volatile bool s_force_link_down = false;
+
+
+#define CH390_LOCK(emac)   xSemaphoreTake((emac)->spi_lock, portMAX_DELAY)
+#define CH390_UNLOCK(emac) xSemaphoreGive((emac)->spi_lock)
+
+// Internal stop/start helpers — caller must hold spi_lock.
+static void ch390_stop_locked(emac_ch390_t *emac) {
+    ch390_reg_write(CH390_IMR, 0x00);
+    uint8_t rcr;
+    ch390_reg_read(CH390_RCR, &rcr);
+    ch390_reg_write(CH390_RCR, rcr & ~RCR_RXEN);
+}
+
+static void ch390_start_locked(emac_ch390_t *emac) {
+    ch390_reg_write(CH390_MPTRCR, MPTRCR_RST_RX);
+    ch390_reg_write(CH390_ISR, ISR_CLR_STATUS);
+    ch390_reg_write(CH390_IMR, IMR_PAR | IMR_ROOI | IMR_ROI | IMR_PRI);
+    uint8_t rcr;
+    ch390_reg_read(CH390_RCR, &rcr);
+    ch390_reg_write(CH390_RCR, rcr | RCR_RXEN);
+}
+
+// Drop a received frame by advancing the RX SRAM read pointer past it.
+// Caller must hold spi_lock.
+static void ch390_drop_frame(uint16_t length) {
+    uint8_t mrrh, mrrl;
+    ch390_reg_read(CH390_MRRH, &mrrh);
+    ch390_reg_read(CH390_MRRL, &mrrl);
+    uint16_t addr = (mrrh << 8) | mrrl;
+    addr += length;  // includes 4B header already consumed
+    if (addr >= 0x4000) addr -= 0x3400;
+    ch390_reg_write(CH390_MRRH, addr >> 8);
+    ch390_reg_write(CH390_MRRL, addr & 0xFF);
+}
+
+// Full software reset + register reinit. Caller must hold spi_lock.
+// Does NOT enable RX/interrupts — caller must call ch390_start_locked() afterwards.
+// Returns true if the chip responded correctly after reset, false if SPI/chip is dead.
+static bool ch390_reset_and_reinit_locked(emac_ch390_t *emac) {
+    // Software reset
+    ch390_reg_write(CH390_NCR, NCR_RST);
+    bool reset_ok = false;
+    for (int i = 0; i < 100; i++) {
+        vTaskDelay(pdMS_TO_TICKS(2));
+        uint8_t ncr;
+        ch390_reg_read(CH390_NCR, &ncr);
+        if (!(ncr & NCR_RST)) { reset_ok = true; break; }
+    }
+    if (!reset_ok) {
+        _LOG_A("CH390: software reset did not complete (NCR_RST stuck)\n");
+    }
+
+    // Power on internal PHY (reset clears GPR back to default)
+    ch390_reg_write(CH390_GPR, 0x00);   // Bit 0 = PHYPD, 0 = PHY powered on
+    vTaskDelay(pdMS_TO_TICKS(10));       // mac and phy register won't be accessible within at least 1ms
+
+    ch390_reg_write(CH390_NCR, 0x00);
+    ch390_reg_write(CH390_WCR, 0x00);
+    ch390_reg_write(CH390_TCR, 0x00);
+    ch390_reg_write(CH390_RCR, RCR_DIS_CRC | RCR_ALL);
+    ch390_reg_write(CH390_TCR2, TCR2_RLCP);
+    ch390_reg_write(CH390_TCSCR, TCSCR_IPCSE | TCSCR_TCPCSE | TCSCR_UDPCSE);   // HW TX checksum
+    ch390_reg_write(CH390_RCSCSR, 0x00);
+    ch390_reg_write(CH390_INTCR, 0x00);            // INT pin: push-pull, active high
+    ch390_reg_write(CH390_INTCKCR, 0x00);          // Clear INT pin clock output
+    ch390_reg_write(CH390_RLENCR, RLENCR_RXLEN_EN | RLENCR_RXLEN_DEFAULT);  // RX length limit 1536
+    ch390_reg_write(CH390_NSR, NSR_WAKEST | NSR_TX2END | NSR_TX1END);
+
+    // Hardware flow-control
+    ch390_reg_write(CH390_BPTR, 0x3F);                              // Back pressure threshold
+    ch390_reg_write(CH390_FCTR, FCTR_HWOT(3) | FCTR_LWOT(8));       // High/low water marks
+    ch390_reg_write(CH390_FCR, FCR_FLOW_ENABLE);
+
+    // Clear multicast hash table and enable broadcast reception
+    ch390_reg_write(CH390_BCASTCR, 0x00);
+    for (int i = 0; i < 7; i++)
+        ch390_reg_write(CH390_MAR + i, 0x00);
+    ch390_reg_write(CH390_MAR + 7, 0x80);  // Enable broadcast packet reception
+
+    // Restore MAC address
+    for (int i = 0; i < 6; i++)
+        ch390_reg_write(CH390_PAR + i, emac->addr[i]);
+
+    // Verify chip is alive by reading back VID
+    uint8_t vid_l = 0;
+    ch390_reg_read(CH390_VIDL, &vid_l);
+    if (vid_l != CH390_VID_L) {
+        _LOG_A("CH390: chip not responding after reset (VID_L=0x%02X, expected 0x%02X)\n",
+               vid_l, CH390_VID_L);
+        return false;
+    }
+
+    // Explicitly restart PHY auto-negotiation after reset.
+    // The PHY powers up with default BMCR which may not have ANEN set on
+    // all revisions; kicking autoneg ensures link comes back reliably.
+    uint16_t bmcr;
+    ch390_phy_reg_read(PHY_BMCR, &bmcr);
+    bmcr |= BMCR_ANEG_EN | BMCR_ANEG_RST;
+    ch390_phy_reg_write(PHY_BMCR, bmcr);
+
+    // Force phy_get_link() to report one link-DOWN cycle so the IDF driver
+    // sees a DOWN→UP transition and fires proper events (DHCP, ARP flush).
+    s_force_link_down = true;
+
+    return true;
+}
+
+// ISR handler — notifies rx task on CH390 interrupt
+static void IRAM_ATTR ch390_isr_handler(void *arg) {
+    emac_ch390_t *emac = (emac_ch390_t *)arg;
+    BaseType_t high_task_wakeup = pdFALSE;
+    vTaskNotifyGiveFromISR(emac->rx_task, &high_task_wakeup);
+    if (high_task_wakeup) portYIELD_FROM_ISR();
+}
+
+// RX task — matches reference emac_ch390_task structure
+static void ch390_rx_task(void *arg) {
+    emac_ch390_t *emac = (emac_ch390_t *)arg;
+    uint8_t status = 0;
+    uint8_t *buffer;
+    while (1) {
+        // Wait for ISR notification or 1000ms timeout
+        if (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1000)) == 0 &&
+                gpio_get_level((gpio_num_t)CH390_INT) == 0) {
+            continue;   // no notification and no interrupt asserted
+        }
+
+        // read and clear interrupt status
+        CH390_LOCK(emac);
+        ch390_reg_read(CH390_ISR, &status);
+        ch390_reg_write(CH390_ISR, status);
+        CH390_UNLOCK(emac);
+
+        // RX FIFO overflow — reset RX path
+        if (status & (ISR_ROS | ISR_ROO)) {
+            _LOG_W("CH390: RX overflow (ISR=0x%02X), resetting RX\n", status);
+            CH390_LOCK(emac);
+            ch390_stop_locked(emac);
+            esp_rom_delay_us(1000);
+            ch390_start_locked(emac);
+            CH390_UNLOCK(emac);
+            continue;
+        }
+
+        /* packet received */
+        if (status & ISR_PR) {
+            do {
+                uint32_t frame_len = 0;
+                if (emac->parent.receive(&emac->parent, emac->rx_buffer, &frame_len) == ESP_OK) {
+                    if (frame_len == 0) {
+                        break;
+                    }
+                    /* allocate memory and check whether allocation failed */
+                    buffer = (uint8_t *)malloc(frame_len);
+                    if (buffer == NULL) {
+                        _LOG_A("CH390: no memory for receive buffer\n");
+                        continue;
+                    }
+                    /* pass the buffer to stack (e.g. TCP/IP layer) */
+                    memcpy(buffer, emac->rx_buffer, frame_len);
+                    emac->eth->stack_input(emac->eth, buffer, frame_len);
+                } else {
+                    _LOG_W("CH390: frame read failed\n");
+                    break;
+                }
+            } while (1);
+
+            // Yield briefly after draining all pending packets.
+            vTaskDelay(1);
+        }
+    }
+    vTaskDelete(NULL);
+}
+
+static esp_err_t ch390_mac_set_mediator(esp_eth_mac_t *mac, esp_eth_mediator_t *eth) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    emac->eth = eth;
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_init(esp_eth_mac_t *mac) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+
+    CH390_LOCK(emac);
+    esp_read_mac(emac->addr, ESP_MAC_ETH);
+    if (!ch390_reset_and_reinit_locked(emac)) {
+        _LOG_A("CH390: chip init failed — check SPI wiring\n");
+    }
+    CH390_UNLOCK(emac);
+
+    // Configure INT pin as input with pull-down (active high from CH390, matching INTCR config)
+    gpio_set_direction((gpio_num_t)CH390_INT, GPIO_MODE_INPUT);
+    gpio_set_pull_mode((gpio_num_t)CH390_INT, GPIO_PULLDOWN_ONLY);
+    gpio_set_intr_type((gpio_num_t)CH390_INT, GPIO_INTR_POSEDGE);
+    esp_err_t isr_err = gpio_install_isr_service(0);
+    if (isr_err != ESP_OK && isr_err != ESP_ERR_INVALID_STATE) {
+        _LOG_A("CH390: gpio_install_isr_service failed: %s\n", esp_err_to_name(isr_err));
+    }
+    gpio_isr_handler_add((gpio_num_t)CH390_INT, ch390_isr_handler, emac);
+    gpio_intr_enable((gpio_num_t)CH390_INT);
+    _LOG_D("CH390: INT pin %d configured (active high, posedge)\n", CH390_INT);
+
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_deinit(esp_eth_mac_t *mac) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    gpio_isr_handler_remove((gpio_num_t)CH390_INT);
+    gpio_intr_disable((gpio_num_t)CH390_INT);
+    if (emac->rx_task) {
+        vTaskDelete(emac->rx_task);
+        emac->rx_task = NULL;
+    }
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_start(esp_eth_mac_t *mac) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    CH390_LOCK(emac);
+    ch390_start_locked(emac);
+    CH390_UNLOCK(emac);
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_stop(esp_eth_mac_t *mac) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    CH390_LOCK(emac);
+    ch390_stop_locked(emac);
+    CH390_UNLOCK(emac);
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_transmit(esp_eth_mac_t *mac, uint8_t *buf, uint32_t length) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    if (length > ETH_MAX_PACKET_SIZE) return ESP_ERR_INVALID_SIZE;
+
+    CH390_LOCK(emac);
+
+    // Write packet data to TX memory
+    ch390_mem_write(buf, length);
+
+    // Check if last transmit is complete (poll TCR_TXREQ)
+    uint8_t tcr;
+    int64_t wait_time = esp_timer_get_time();
+    do {
+        ch390_reg_read(CH390_TCR, &tcr);
+    } while ((tcr & TCR_TXREQ) && ((esp_timer_get_time() - wait_time) < 1000));
+
+    if (tcr & TCR_TXREQ) {
+        _LOG_W("CH390: last transmit still in progress, cannot send\n");
+        CH390_UNLOCK(emac);
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    // Set TX packet length
+    ch390_reg_write(CH390_TXPLL, length & 0xFF);
+    ch390_reg_write(CH390_TXPLH, (length >> 8) & 0xFF);
+
+    // Issue TX polling command
+    ch390_reg_read(CH390_TCR, &tcr);
+    ch390_reg_write(CH390_TCR, tcr | TCR_TXREQ);
+
+    CH390_UNLOCK(emac);
+    return ESP_OK;
+}
+
+// Receive one packet from the CH390 RX SRAM.
+// Matches the Espressif reference emac_ch390_receive pattern.
+static esp_err_t ch390_mac_receive(esp_eth_mac_t *mac, uint8_t *buf, uint32_t *length) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+
+    CH390_LOCK(emac);
+
+    // Double dummy read to get the most updated data
+    uint8_t rxbyte;
+    ch390_reg_read(CH390_MRCMDX, &rxbyte);
+    ch390_reg_read(CH390_MRCMDX, &rxbyte);
+
+    // If rxbyte indicates error state, do stop/start recovery
+    if (rxbyte & CH390_PKT_ERR) {
+        ch390_stop_locked(emac);
+        esp_rom_delay_us(1000);
+        ch390_start_locked(emac);
+        CH390_UNLOCK(emac);
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+
+    if (rxbyte & CH390_PKT_RDY) {
+        // Read 4-byte RX header: flag, status, length_lo, length_hi
+        __attribute__((aligned(4))) uint8_t rx_header[CH390_RX_HDR_SIZE];
+        ch390_mem_read(rx_header, CH390_RX_HDR_SIZE);
+
+        uint8_t status = rx_header[1];
+        *length = (rx_header[3] << 8) + rx_header[2];
+
+        if (status & RSR_ERR_MASK) {
+            ch390_drop_frame(*length);
+            *length = 0;
+            CH390_UNLOCK(emac);
+            return ESP_ERR_INVALID_RESPONSE;
+        } else if (*length > ETH_MAX_PACKET_SIZE) {
+            // Reset rx memory pointer
+            ch390_reg_write(CH390_MPTRCR, MPTRCR_RST_RX);
+            CH390_UNLOCK(emac);
+            return ESP_ERR_INVALID_RESPONSE;
+        } else {
+            ch390_mem_read(buf, *length);
+            *length -= ETH_CRC_LEN;
+        }
+    } else {
+        *length = 0;
+    }
+
+    CH390_UNLOCK(emac);
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_set_addr(esp_eth_mac_t *mac, uint8_t *addr) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    memcpy(emac->addr, addr, 6);
+    CH390_LOCK(emac);
+    for (int i = 0; i < 6; i++) {
+        ch390_reg_write(CH390_PAR + i, addr[i]);
+    }
+    CH390_UNLOCK(emac);
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_get_addr(esp_eth_mac_t *mac, uint8_t *addr) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    memcpy(addr, emac->addr, 6);
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_set_speed(esp_eth_mac_t *mac, eth_speed_t speed) {
+    // Speed is managed by PHY auto-negotiation, nothing to configure in MAC
+    _LOG_D("CH390 Speed set to %s\n", speed == ETH_SPEED_100M ? "100M" : "10M");
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_set_duplex(esp_eth_mac_t *mac, eth_duplex_t duplex) {
+    // Duplex is managed by PHY auto-negotiation, nothing to configure in MAC
+    _LOG_D("CH390 Duplex set to %s\n", duplex == ETH_DUPLEX_FULL ? "Full" : "Half");
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_set_link(esp_eth_mac_t *mac, eth_link_t link) {
+    esp_err_t ret = ESP_OK;
+    switch (link) {
+    case ETH_LINK_UP:
+        ret = mac->start(mac);
+        break;
+    case ETH_LINK_DOWN:
+        ret = mac->stop(mac);
+        break;
+    default:
+        break;
+    }
+    _LOG_I("CH390 Link %s\n", link == ETH_LINK_UP ? "Up" : "Down");
+    return ret;
+}
+
+static esp_err_t ch390_mac_set_promiscuous(esp_eth_mac_t *mac, bool enable) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    CH390_LOCK(emac);
+    uint8_t rcr;
+    ch390_reg_read(CH390_RCR, &rcr);
+    if (enable) rcr |= RCR_PRMSC;
+    else        rcr &= ~RCR_PRMSC;
+    ch390_reg_write(CH390_RCR, rcr);
+    CH390_UNLOCK(emac);
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_enable_flow_ctrl(esp_eth_mac_t *mac, bool enable) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    emac->flow_ctrl_enabled = enable;
+    return ESP_OK;
+}
+
+static void ch390_enable_flow_ctrl_hw(emac_ch390_t *emac, bool enable) {
+    CH390_LOCK(emac);
+    if (enable) {
+        // Send jam pattern when RX free space < 3K bytes
+        ch390_reg_write(CH390_BPTR, 0x3F);
+        // Flow control thresholds: high water = 3K, low water = 8K
+        ch390_reg_write(CH390_FCTR, FCTR_HWOT(3) | FCTR_LWOT(8));
+        ch390_reg_write(CH390_FCR, FCR_FLOW_ENABLE);
+    } else {
+        ch390_reg_write(CH390_FCR, 0x00);
+    }
+    CH390_UNLOCK(emac);
+}
+
+static esp_err_t ch390_mac_set_peer_pause_ability(esp_eth_mac_t *mac, uint32_t ability) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    if (emac->flow_ctrl_enabled && ability) {
+        ch390_enable_flow_ctrl_hw(emac, true);
+    } else {
+        ch390_enable_flow_ctrl_hw(emac, false);
+    }
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_write_phy_reg(esp_eth_mac_t *mac, uint32_t phy_addr, uint32_t phy_reg, uint32_t reg_value) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    CH390_LOCK(emac);
+    ch390_phy_reg_write(phy_reg, (uint16_t)reg_value);
+    CH390_UNLOCK(emac);
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_read_phy_reg(esp_eth_mac_t *mac, uint32_t phy_addr, uint32_t phy_reg, uint32_t *reg_value) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    CH390_LOCK(emac);
+    uint16_t val;
+    ch390_phy_reg_read(phy_reg, &val);
+    *reg_value = val;
+    CH390_UNLOCK(emac);
+    return ESP_OK;
+}
+
+static esp_err_t ch390_mac_del(esp_eth_mac_t *mac) {
+    emac_ch390_t *emac = __containerof(mac, emac_ch390_t, parent);
+    if (emac->rx_task) vTaskDelete(emac->rx_task);
+    if (emac->spi_lock) vSemaphoreDelete(emac->spi_lock);
+    heap_caps_free(emac->rx_buffer);
+    free(emac);
+    return ESP_OK;
+}
+
+static esp_eth_mac_t *ch390_mac_new(void) {
+    emac_ch390_t *emac = (emac_ch390_t *)calloc(1, sizeof(emac_ch390_t));
+    if (!emac) return NULL;
+
+    emac->parent.set_mediator        = ch390_mac_set_mediator;
+    emac->parent.init                = ch390_mac_init;
+    emac->parent.deinit              = ch390_mac_deinit;
+    emac->parent.start               = ch390_mac_start;
+    emac->parent.stop                = ch390_mac_stop;
+    emac->parent.del                 = ch390_mac_del;
+    emac->parent.write_phy_reg       = ch390_mac_write_phy_reg;
+    emac->parent.read_phy_reg        = ch390_mac_read_phy_reg;
+    emac->parent.set_addr            = ch390_mac_set_addr;
+    emac->parent.get_addr            = ch390_mac_get_addr;
+    emac->parent.set_speed           = ch390_mac_set_speed;
+    emac->parent.set_duplex          = ch390_mac_set_duplex;
+    emac->parent.set_link            = ch390_mac_set_link;
+    emac->parent.set_promiscuous     = ch390_mac_set_promiscuous;
+    emac->parent.set_peer_pause_ability = ch390_mac_set_peer_pause_ability;
+    emac->parent.enable_flow_ctrl    = ch390_mac_enable_flow_ctrl;
+    emac->parent.transmit            = ch390_mac_transmit;
+    emac->parent.receive             = ch390_mac_receive;
+
+    emac->spi_lock = xSemaphoreCreateMutex();
+    if (!emac->spi_lock) { free(emac); return NULL; }
+
+    emac->rx_buffer = (uint8_t *)heap_caps_malloc(1536 + CH390_RX_HDR_SIZE, MALLOC_CAP_DMA);
+    if (!emac->rx_buffer) { vSemaphoreDelete(emac->spi_lock); free(emac); return NULL; }
+
+    BaseType_t ret = xTaskCreatePinnedToCore(ch390_rx_task, "ch390_rx", 4096,
+                                              emac, 8, &emac->rx_task, 0);
+    if (ret != pdPASS) {
+        heap_caps_free(emac->rx_buffer);
+        vSemaphoreDelete(emac->spi_lock);
+        free(emac);
+        return NULL;
+    }
+
+    s_emac = emac;
+
+    return &emac->parent;
+}
+
+// =====================================================================
+// PHY driver (esp_eth_phy_t implementation)
+// =====================================================================
+
+typedef struct {
+    esp_eth_phy_t parent;
+    esp_eth_mediator_t *eth;
+    int addr;
+    eth_link_t link;
+    eth_speed_t negotiated_speed;
+    eth_duplex_t negotiated_duplex;
+} phy_ch390_t;
+
+static esp_err_t ch390_phy_set_mediator(esp_eth_phy_t *phy, esp_eth_mediator_t *eth) {
+    phy_ch390_t *p = __containerof(phy, phy_ch390_t, parent);
+    p->eth = eth;
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_init(esp_eth_phy_t *phy) {
+    // PHY is integrated, no external init needed beyond what MAC init does
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_deinit(esp_eth_phy_t *phy) {
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_reset(esp_eth_phy_t *phy) {
+    phy_ch390_t *p = __containerof(phy, phy_ch390_t, parent);
+    uint32_t bmcr;
+    p->eth->phy_reg_read(p->eth, p->addr, PHY_BMCR, &bmcr);
+    bmcr |= BMCR_RST;
+    p->eth->phy_reg_write(p->eth, p->addr, PHY_BMCR, bmcr);
+    // Wait for reset to complete
+    for (int i = 0; i < 100; i++) {
+        vTaskDelay(pdMS_TO_TICKS(10));
+        p->eth->phy_reg_read(p->eth, p->addr, PHY_BMCR, &bmcr);
+        if (!(bmcr & BMCR_RST)) return ESP_OK;
+    }
+    return ESP_ERR_TIMEOUT;
+}
+
+static esp_err_t ch390_phy_reset_hw(esp_eth_phy_t *phy) {
+    // No hardware reset pin available
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_negotiate(esp_eth_phy_t *phy) {
+    phy_ch390_t *p = __containerof(phy, phy_ch390_t, parent);
+    uint32_t bmcr;
+
+    // Read current BMCR
+    p->eth->phy_reg_read(p->eth, p->addr, PHY_BMCR, &bmcr);
+    _LOG_D("CH390: negotiate start BMCR=0x%04X\n", (uint16_t)bmcr);
+
+    // Enable auto-negotiation and restart
+    bmcr |= BMCR_ANEG_EN | BMCR_ANEG_RST;
+    p->eth->phy_reg_write(p->eth, p->addr, PHY_BMCR, bmcr);
+
+    // Wait for completion (up to 5 seconds)
+    uint32_t bmsr;
+    for (int i = 0; i < 500; i++) {
+        vTaskDelay(pdMS_TO_TICKS(10));
+        p->eth->phy_reg_read(p->eth, p->addr, PHY_BMSR, &bmsr);
+        if (bmsr & BMSR_ANEG_DONE) break;
+        if (i % 100 == 99) {
+            _LOG_D("CH390: waiting for autoneg... BMSR=0x%04X\n", (uint16_t)bmsr);
+        }
+    }
+    _LOG_I("CH390: negotiate done BMSR=0x%04X link=%s\n", (uint16_t)bmsr,
+                  (bmsr & BMSR_LINK) ? "UP" : "DOWN");
+
+    // Read BMCR to determine resolved speed/duplex (reference reads BMCR, not ANLPAR)
+    p->eth->phy_reg_read(p->eth, p->addr, PHY_BMCR, &bmcr);
+    p->negotiated_speed  = (bmcr & BMCR_SPEED100) ? ETH_SPEED_100M : ETH_SPEED_10M;
+    p->negotiated_duplex = (bmcr & BMCR_DUPLEX)   ? ETH_DUPLEX_FULL : ETH_DUPLEX_HALF;
+
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_get_link(esp_eth_phy_t *phy) {
+    phy_ch390_t *p = __containerof(phy, phy_ch390_t, parent);
+
+    // After a chip reinit, force one link-DOWN report so the IDF driver
+    // sees a transition and fires CONNECTED/GOT_IP events on recovery.
+    if (s_force_link_down) {
+        s_force_link_down = false;
+        if (p->link != ETH_LINK_DOWN) {
+            p->link = ETH_LINK_DOWN;
+            p->eth->on_state_changed(p->eth, ETH_STATE_LINK,
+                         reinterpret_cast<void *>(static_cast<intptr_t>(ETH_LINK_DOWN)));
+        }
+        return ESP_OK;
+    }
+
+    uint32_t bmsr;
+    // Read BMSR twice: first read clears latched-low link bit, second gives real-time value
+    p->eth->phy_reg_read(p->eth, p->addr, PHY_BMSR, &bmsr);
+    p->eth->phy_reg_read(p->eth, p->addr, PHY_BMSR, &bmsr);
+
+    eth_link_t new_link = (bmsr & BMSR_LINK) ? ETH_LINK_UP : ETH_LINK_DOWN;
+    if (p->link != new_link) {
+        // When link comes up, report speed/duplex before link state
+        if (new_link == ETH_LINK_UP) {
+            // Read BMCR for resolved speed/duplex (reference reads BMCR, not ANLPAR)
+            uint32_t bmcr_val;
+            p->eth->phy_reg_read(p->eth, p->addr, PHY_BMCR, &bmcr_val);
+            eth_speed_t speed  = (bmcr_val & BMCR_SPEED100) ? ETH_SPEED_100M : ETH_SPEED_10M;
+            eth_duplex_t duplex = (bmcr_val & BMCR_DUPLEX)   ? ETH_DUPLEX_FULL : ETH_DUPLEX_HALF;
+            p->eth->on_state_changed(p->eth, ETH_STATE_SPEED,
+                         reinterpret_cast<void *>(static_cast<intptr_t>(speed)));
+            p->eth->on_state_changed(p->eth, ETH_STATE_DUPLEX,
+                         reinterpret_cast<void *>(static_cast<intptr_t>(duplex)));
+        }
+        p->link = new_link;
+        p->eth->on_state_changed(p->eth, ETH_STATE_LINK,
+                     reinterpret_cast<void *>(static_cast<intptr_t>(new_link)));
+    }
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_pwrctl(esp_eth_phy_t *phy, bool enable) {
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_set_addr(esp_eth_phy_t *phy, uint32_t addr) {
+    phy_ch390_t *p = __containerof(phy, phy_ch390_t, parent);
+    p->addr = addr;
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_get_addr(esp_eth_phy_t *phy, uint32_t *addr) {
+    phy_ch390_t *p = __containerof(phy, phy_ch390_t, parent);
+    *addr = p->addr;
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_advertise_pause_ability(esp_eth_phy_t *phy, uint32_t ability) {
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_loopback(esp_eth_phy_t *phy, bool enable) {
+    phy_ch390_t *p = __containerof(phy, phy_ch390_t, parent);
+    uint32_t bmcr;
+    p->eth->phy_reg_read(p->eth, p->addr, PHY_BMCR, &bmcr);
+    if (enable) bmcr |= BMCR_LOOPBACK;
+    else        bmcr &= ~BMCR_LOOPBACK;
+    p->eth->phy_reg_write(p->eth, p->addr, PHY_BMCR, bmcr);
+    return ESP_OK;
+}
+
+static esp_err_t ch390_phy_del(esp_eth_phy_t *phy) {
+    phy_ch390_t *p = __containerof(phy, phy_ch390_t, parent);
+    free(p);
+    return ESP_OK;
+}
+
+static esp_eth_phy_t *ch390_phy_new(void) {
+    phy_ch390_t *p = (phy_ch390_t *)calloc(1, sizeof(phy_ch390_t));
+    if (!p) return NULL;
+
+    p->addr = 1; // DM9051/CH390 internal PHY address
+    p->link = ETH_LINK_DOWN;
+
+    p->parent.set_mediator             = ch390_phy_set_mediator;
+    p->parent.init                     = ch390_phy_init;
+    p->parent.deinit                   = ch390_phy_deinit;
+    p->parent.reset                    = ch390_phy_reset;
+    p->parent.reset_hw                 = ch390_phy_reset_hw;
+    p->parent.negotiate                = ch390_phy_negotiate;
+    p->parent.get_link                 = ch390_phy_get_link;
+    p->parent.pwrctl                   = ch390_phy_pwrctl;
+    p->parent.set_addr                 = ch390_phy_set_addr;
+    p->parent.get_addr                 = ch390_phy_get_addr;
+    p->parent.advertise_pause_ability  = ch390_phy_advertise_pause_ability;
+    p->parent.loopback                 = ch390_phy_loopback;
+    p->parent.del                      = ch390_phy_del;
+
+    return &p->parent;
+}
+
+// =====================================================================
+// Public API
+// =====================================================================
+
+bool ch390_detect(void) {
+    _LOG_I("CH390: Probing SPI (SCK=%d MOSI=%d MISO=%d CS=%d)...\n",
+             CH390_SCK, CH390_MOSI, CH390_MISO, CH390_CS);
+
+    // Initialize SPI bus
+    spi_bus_config_t bus = {};
+    bus.mosi_io_num = CH390_MOSI;
+    bus.miso_io_num = CH390_MISO;
+    bus.sclk_io_num = CH390_SCK;
+    bus.quadwp_io_num = -1;
+    bus.quadhd_io_num = -1;
+    bus.max_transfer_sz = 1600;
+
+    // Setup DMA channel, let driver pick the best one if available
+    esp_err_t ret = spi_bus_initialize(s_spi_host, &bus, SPI_DMA_CH_AUTO);
+    if (ret != ESP_OK) {
+        _LOG_A("CH390: SPI bus init failed: %s (%d)\n", esp_err_to_name(ret), ret);
+        return false;
+    }
+    _LOG_D("CH390: SPI bus initialized OK\n");
+
+    // Add CH390D SPI device: 1 cmd bit + 7 addr bits, mode 0, 1 MHz for probe
+    spi_device_interface_config_t dev = {};
+    dev.command_bits = 1;
+    dev.address_bits = 7;
+    dev.mode = 0;
+    dev.clock_speed_hz = 1000000; // 1 MHz for safe probing
+    dev.spics_io_num = CH390_CS;
+    dev.queue_size = 1;
+    dev.flags = SPI_DEVICE_HALFDUPLEX;  // CH390D uses separate read/write phases
+
+    ret = spi_bus_add_device(s_spi_host, &dev, &s_spi);
+    if (ret != ESP_OK) {
+        _LOG_A("CH390: SPI device add failed: %s (%d)\n", esp_err_to_name(ret), ret);
+        spi_bus_free(s_spi_host);
+        return false;
+    }
+    _LOG_D("CH390: SPI device added OK\n");
+
+    // Read chip ID
+    uint8_t vid_l = 0, vid_h = 0, pid_l = 0, pid_h = 0;
+    ch390_reg_read(CH390_VIDL, &vid_l);
+    ch390_reg_read(CH390_VIDH, &vid_h);
+    ch390_reg_read(CH390_PIDL, &pid_l);
+    ch390_reg_read(CH390_PIDH, &pid_h);
+    _LOG_I("CH390: Probed VID=%02X%02X PID=%02X%02X\n", vid_h, vid_l, pid_h, pid_l);
+
+    if (vid_h == CH390_VID_H && vid_l == CH390_VID_L &&
+        pid_h == CH390_PID_H && pid_l == CH390_PID_L) {
+        _LOG_I("CH390D detected!\n");
+
+        // Increase SPI clock to 10 MHz for normal operation
+        spi_bus_remove_device(s_spi);
+        dev.clock_speed_hz = 10000000;
+        spi_bus_add_device(s_spi_host, &dev, &s_spi);
+
+        EthPresent = true;
+        return true;
+    }
+
+    // Not found — release SPI resources
+    _LOG_I("CH390D not found, releasing SPI bus for LCD\n");
+    spi_bus_remove_device(s_spi);
+    s_spi = NULL;
+    spi_bus_free(s_spi_host);
+    return false;
+}
+
+// Ethernet event handlers
+static void eth_event_handler(void *arg, esp_event_base_t event_base,
+                              int32_t event_id, void *event_data) {
+    uint8_t mac[6];
+    esp_eth_handle_t eth_handle = *(esp_eth_handle_t *)event_data;
+
+    switch (event_id) {
+    case ETHERNET_EVENT_CONNECTED:
+        esp_eth_ioctl(eth_handle, ETH_CMD_G_MAC_ADDR, mac);
+        _LOG_I("Ethernet Link Up - MAC: %02X:%02X:%02X:%02X:%02X:%02X\n",
+                 mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+        EthConnected = true;
+        // DHCP lifecycle is managed by esp_eth_stop/start via the
+        // esp_eth_netif_glue layer (esp_netif_action_start/connected).
+        break;
+    case ETHERNET_EVENT_DISCONNECTED:
+        _LOG_I("Ethernet Link Down\n");
+        EthConnected = false;
+        EthHasIP = false;
+        break;
+    case ETHERNET_EVENT_START:
+        _LOG_I("Ethernet Started\n");
+        // DHCP is started in ETHERNET_EVENT_CONNECTED, not here.
+        // Starting it on START (before link is up) causes a duplicate
+        // DHCP cycle and double GOT_IP events.
+        break;
+    case ETHERNET_EVENT_STOP:
+        _LOG_W("Ethernet Stopped\n");
+        EthConnected = false;
+        EthHasIP = false;
+        break;
+    default:
+        break;
+    }
+}
+
+static char eth_ip_str[16] = "";
+
+const char* ch390_get_ip(void) {
+    return eth_ip_str;
+}
+
+static void eth_got_ip_handler(void *arg, esp_event_base_t event_base,
+                               int32_t event_id, void *event_data) {
+    ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
+    const esp_netif_ip_info_t *ip = &event->ip_info;
+    snprintf(eth_ip_str, sizeof(eth_ip_str), IPSTR, IP2STR(&ip->ip));
+    _LOG_I("Ethernet Got IP: %s\n", eth_ip_str);
+    EthHasIP = true;
+
+    _LOG_I("Ethernet Netmask: " IPSTR " GW: " IPSTR "\n",
+           IP2STR(&ip->netmask), IP2STR(&ip->gw));
+
+    // Get DNS server from the Ethernet netif
+    esp_netif_dns_info_t dns;
+    if (event->esp_netif && esp_netif_get_dns_info(event->esp_netif, ESP_NETIF_DNS_MAIN, &dns) == ESP_OK) {
+        char dns_str[16];
+        snprintf(dns_str, sizeof(dns_str), IPSTR, IP2STR(&dns.ip.u_addr.ip4));
+        onGotIP(dns_str);
+    } else {
+        onGotIP(NULL);
+    }
+}
+
+static void eth_lost_ip_handler(void *arg, esp_event_base_t event_base,
+                                int32_t event_id, void *event_data) {
+    (void)arg;
+    (void)event_base;
+    (void)event_id;
+    (void)event_data;
+    EthHasIP = false;
+    eth_ip_str[0] = '\0';
+    _LOG_W("Ethernet lost IP\n");
+}
+
+esp_err_t ch390_eth_init(void) {
+    if (!s_spi) return ESP_ERR_INVALID_STATE;
+
+    // Initialize TCP/IP stack and event loop
+    // esp_event_loop_create_default() is safe to call multiple times — returns
+    // ESP_ERR_INVALID_STATE if already created (by Arduino WiFi).
+    // Must be created before esp_netif_new() which depends on it.
+    esp_err_t err = esp_event_loop_create_default();
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        _LOG_A("CH390: event loop create failed: %s\n", esp_err_to_name(err));
+        return err;
+    }
+    ESP_ERROR_CHECK(esp_netif_init());
+
+    // Create MAC and PHY
+    esp_eth_mac_t *mac = ch390_mac_new();
+    if (!mac) {
+        _LOG_A("CH390: Failed to create MAC\n");
+        return ESP_FAIL;
+    }
+
+    esp_eth_phy_t *phy = ch390_phy_new();
+    if (!phy) {
+        _LOG_A("CH390: Failed to create PHY\n");
+        mac->del(mac);
+        return ESP_FAIL;
+    }
+
+    // Install Ethernet driver
+    esp_eth_config_t eth_config = ETH_DEFAULT_CONFIG(mac, phy);
+    esp_eth_handle_t eth_handle = NULL;
+    esp_err_t ret = esp_eth_driver_install(&eth_config, &eth_handle);
+    if (ret != ESP_OK) {
+        _LOG_A("CH390: Ethernet driver install failed: %s\n", esp_err_to_name(ret));
+        return ret;
+    }
+
+    // Set MAC address from ESP32's Ethernet MAC slot
+    uint8_t eth_mac[6];
+    esp_read_mac(eth_mac, ESP_MAC_ETH);
+    esp_eth_ioctl(eth_handle, ETH_CMD_S_MAC_ADDR, eth_mac);
+    s_eth_handle = eth_handle;
+
+    // Create netif for Ethernet (DHCP enabled by default)
+    esp_netif_config_t netif_cfg = ESP_NETIF_DEFAULT_ETH();
+    esp_netif_t *eth_netif = esp_netif_new(&netif_cfg);
+    if (!eth_netif) {
+        _LOG_A("CH390: Failed to create netif\n");
+        return ESP_FAIL;
+    }
+    s_eth_netif = eth_netif;
+
+    // Attach driver to TCP/IP stack
+    esp_eth_netif_glue_handle_t glue = esp_eth_new_netif_glue(eth_handle);
+    esp_netif_attach(eth_netif, glue);
+
+    // Register event handlers
+    esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID, &eth_event_handler, NULL);
+    esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &eth_got_ip_handler, NULL);
+    esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_LOST_IP, &eth_lost_ip_handler, NULL);
+
+    // Start Ethernet
+    ret = esp_eth_start(eth_handle);
+    if (ret != ESP_OK) {
+        _LOG_A("CH390: Ethernet start failed: %s\n", esp_err_to_name(ret));
+        return ret;
+    }
+
+    _LOG_I("CH390D Ethernet initialized, DHCP started\n");
+    return ESP_OK;
+}
+
+#endif // SMARTEVSE_VERSION >= 30 && < 40

--- a/SmartEVSE-3/src/ch390.cpp
+++ b/SmartEVSE-3/src/ch390.cpp
@@ -863,13 +863,15 @@ static void eth_event_handler(void *arg, esp_event_base_t event_base,
         _LOG_I("Ethernet Link Up - MAC: %02X:%02X:%02X:%02X:%02X:%02X\n",
                  mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
         EthConnected = true;
-        // DHCP lifecycle is managed by esp_eth_stop/start via the
-        // esp_eth_netif_glue layer (esp_netif_action_start/connected).
+        // Defer WiFi handling to network_loop() — event task stack is too small
+        WIFImodeChanged = true;
         break;
     case ETHERNET_EVENT_DISCONNECTED:
         _LOG_I("Ethernet Link Down\n");
         EthConnected = false;
         EthHasIP = false;
+        // Defer WiFi re-enable to network_loop() — event task stack is too small
+        WIFImodeChanged = true;
         break;
     case ETHERNET_EVENT_START:
         _LOG_I("Ethernet Started\n");

--- a/SmartEVSE-3/src/ch390.cpp
+++ b/SmartEVSE-3/src/ch390.cpp
@@ -662,24 +662,11 @@ static esp_err_t ch390_phy_negotiate(esp_eth_phy_t *phy) {
 
     // Read current BMCR
     p->eth->phy_reg_read(p->eth, p->addr, PHY_BMCR, &bmcr);
-    _LOG_D("CH390: negotiate start BMCR=0x%04X\n", (uint16_t)bmcr);
 
     // Enable auto-negotiation and restart
     bmcr |= BMCR_ANEG_EN | BMCR_ANEG_RST;
     p->eth->phy_reg_write(p->eth, p->addr, PHY_BMCR, bmcr);
-
-    // Wait for completion (up to 5 seconds)
-    uint32_t bmsr;
-    for (int i = 0; i < 500; i++) {
-        vTaskDelay(pdMS_TO_TICKS(10));
-        p->eth->phy_reg_read(p->eth, p->addr, PHY_BMSR, &bmsr);
-        if (bmsr & BMSR_ANEG_DONE) break;
-        if (i % 100 == 99) {
-            _LOG_D("CH390: waiting for autoneg... BMSR=0x%04X\n", (uint16_t)bmsr);
-        }
-    }
-    _LOG_I("CH390: negotiate done BMSR=0x%04X link=%s\n", (uint16_t)bmsr,
-                  (bmsr & BMSR_LINK) ? "UP" : "DOWN");
+    _LOG_I("CH390: auto-negotiation started (non-blocking)\n");
 
     // Read BMCR to determine resolved speed/duplex (reference reads BMCR, not ANLPAR)
     p->eth->phy_reg_read(p->eth, p->addr, PHY_BMCR, &bmcr);
@@ -819,7 +806,7 @@ bool ch390_detect(void) {
     spi_device_interface_config_t dev = {};
     dev.command_bits = 1;
     dev.address_bits = 7;
-    dev.mode = 0;
+    dev.mode = 3;  // CPOL=1, CPHA=1 (mode 3)
     dev.clock_speed_hz = 1000000; // 1 MHz for safe probing
     dev.spics_io_num = CH390_CS;
     dev.queue_size = 1;

--- a/SmartEVSE-3/src/ch390.h
+++ b/SmartEVSE-3/src/ch390.h
@@ -1,0 +1,214 @@
+/*
+ * CH390D SPI Ethernet MAC/PHY driver for ESP-IDF 4.4 (Arduino ESP32 2.x)
+ *
+ * The CH390D is register-compatible with the DM9051 but has different
+ * Vendor/Product IDs. This driver implements the esp_eth_mac_t / esp_eth_phy_t
+ * interface using the identical register map, bypassing the DM9051 driver's
+ * hard-coded chip ID check.
+ *
+ * SPI protocol: 1 command bit (R/W) + 7 address bits, same as DM9051.
+ */
+
+#ifndef __CH390_H
+#define __CH390_H
+
+#include <Arduino.h>
+
+#if SMARTEVSE_VERSION >= 30 && SMARTEVSE_VERSION < 40
+
+// ---------- Pin mapping for CH390D add-on board (v3) ----------
+// Reuses LCD SPI pins. When CH390D is detected, LCD is disabled.
+#define CH390_SCK       26      // was SPI_SCK  (PIN_LCD_CLK)
+#define CH390_MOSI      33      // was SPI_MOSI (PIN_LCD_SDO_B3)
+#define CH390_MISO      25      // was PIN_LCD_A0_B2
+#define CH390_CS        14      // was PIN_LCD_LED
+#define CH390_INT        5      // INT pin directly connected to ESP32 GPIO5
+
+// ---------- Chip identification ----------
+#define CH390_VID_L     0x00
+#define CH390_VID_H     0x1C
+#define CH390_PID_L     0x51
+#define CH390_PID_H     0x91
+
+// ---------- SPI command bits ----------
+#define CH390_SPI_RD    0
+#define CH390_SPI_WR    1
+
+// ---------- Register map (identical to DM9051) ----------
+#define CH390_NCR       0x00    // Network Control
+#define CH390_NSR       0x01    // Network Status
+#define CH390_TCR       0x02    // TX Control
+#define CH390_TSRA      0x03    // TX Status A
+#define CH390_TSRB      0x04    // TX Status B
+#define CH390_RCR       0x05    // RX Control
+#define CH390_RSR       0x06    // RX Status
+#define CH390_ROCR      0x07    // RX Overflow Count
+#define CH390_BPTR      0x08    // Back Pressure Threshold
+#define CH390_FCTR      0x09    // Flow Control Threshold
+#define CH390_FCR       0x0A    // Flow Control
+#define CH390_EPCR      0x0B    // EEPROM/PHY Control
+#define CH390_EPAR      0x0C    // EEPROM/PHY Address
+#define CH390_EPDRL     0x0D    // EEPROM/PHY Data Low
+#define CH390_EPDRH     0x0E    // EEPROM/PHY Data High
+#define CH390_WCR       0x0F    // Wakeup Control
+#define CH390_PAR       0x10    // Physical (MAC) Address (6 bytes: 0x10-0x15)
+#define CH390_MAR       0x16    // Multicast Address Hash (8 bytes: 0x16-0x1D)
+#define CH390_GPCR      0x1E    // GPIO Control
+#define CH390_GPR       0x1F    // GPIO
+#define CH390_TRPAL     0x22    // TX Read Pointer Low
+#define CH390_TRPAH     0x23    // TX Read Pointer High
+#define CH390_RWPAL     0x24    // RX Write Pointer Low
+#define CH390_RWPAH     0x25    // RX Write Pointer High
+#define CH390_VIDL      0x28    // Vendor ID Low
+#define CH390_VIDH      0x29    // Vendor ID High
+#define CH390_PIDL      0x2A    // Product ID Low
+#define CH390_PIDH      0x2B    // Product ID High
+#define CH390_CHIPR     0x2C    // Chip Revision
+#define CH390_TCR2      0x2D    // TX Control 2
+#define CH390_ATCR      0x30    // Auto-TX Control
+#define CH390_TCSCR     0x31    // TX Checksum Control
+#define CH390_RCSCSR    0x32    // RX Checksum Control/Status
+#define CH390_SBCR      0x38    // SPI Bus Control
+#define CH390_INTCR     0x39    // INT Pin Control
+#define CH390_ALNCR     0x4A    // SPI Alignment Error Count
+#define CH390_SCCR      0x50    // System Clock Control
+#define CH390_RSCCR     0x51    // Recover System Clock Control
+#define CH390_RLENCR    0x52    // RX Data Length Control
+#define CH390_BCASTCR   0x53    // RX Broadcast Control
+#define CH390_INTCKCR   0x54    // INT Pin Clock Output Control
+#define CH390_MPTRCR    0x55    // Memory Pointer Control
+#define CH390_MLEDCR    0x57    // LED Control
+#define CH390_MEMSCR    0x59    // Memory Control
+#define CH390_TMEMR     0x5A    // TX Memory Size
+#define CH390_MBSR      0x5D    // Memory BIST Status
+
+// Memory data access registers
+#define CH390_MRCMDX    0x70    // Memory Read (no addr increment)
+#define CH390_MRCMDX1   0x71    // Memory Read (no pre-fetch)
+#define CH390_MRCMD     0x72    // Memory Read (with addr increment)
+#define CH390_MRRL      0x74    // Memory Read Address Low
+#define CH390_MRRH      0x75    // Memory Read Address High
+#define CH390_MWCMDX    0x76    // Memory Write (no addr increment)
+#define CH390_MWCMD     0x78    // Memory Write (with addr increment)
+#define CH390_MWRL      0x7A    // Memory Write Address Low
+#define CH390_MWRH      0x7B    // Memory Write Address High
+#define CH390_TXPLL     0x7C    // TX Packet Length Low
+#define CH390_TXPLH     0x7D    // TX Packet Length High
+
+// Interrupt registers
+#define CH390_ISR       0x7E    // Interrupt Status
+#define CH390_IMR       0x7F    // Interrupt Mask
+
+// ---------- Register bit definitions ----------
+#define NCR_RST         (1 << 0)    // Software reset
+#define NCR_LBK_MAC     (1 << 1)    // MAC loopback
+
+#define NSR_WAKEST      (1 << 5)
+#define NSR_TX2END      (1 << 3)
+#define NSR_TX1END      (1 << 2)
+#define NSR_LINKST      (1 << 6)    // Link status (1=up)
+
+#define TCR_TXREQ       (1 << 0)    // TX request
+#define TCR2_RLCP       (1 << 6)    // Retry late collision
+
+#define RCR_DIS_CRC     (1 << 4)    // Discard CRC error
+#define RCR_ALL         (1 << 3)    // Receive all multicast
+#define RCR_RXEN        (1 << 0)    // RX enable
+#define RCR_PRMSC       (1 << 1)    // Promiscuous mode
+#define RCR_DIS_LONG    (1 << 5)    // Discard long packets
+
+#define ATCR_AUTO_TX    (1 << 7)    // Auto-transmit
+
+#define TCSCR_IPCSE     (1 << 0)    // IP checksum offload
+#define TCSCR_TCPCSE    (1 << 1)    // TCP checksum offload
+#define TCSCR_UDPCSE    (1 << 2)    // UDP checksum offload
+
+#define MPTRCR_RST_TX   (1 << 1)    // Reset TX memory pointer
+#define MPTRCR_RST_RX   (1 << 0)    // Reset RX memory pointer
+
+#define FCR_FLOW_ENABLE 0x39        // Enable flow control
+
+#define FCTR_HWOT(x)    (((x) & 0xF) << 4)  // Flow control high water overflow threshold
+#define FCTR_LWOT(x)    ((x) & 0xF)         // Flow control low water overflow threshold
+
+#define RLENCR_RXLEN_EN      0x80   // Enable RX data pack length filter
+#define RLENCR_RXLEN_DEFAULT 0x18   // Default MAX length of RX data (div by 64)
+
+#define RSR_ERR_MASK    (0xBF)      // RX status error mask (RF|MF|LCS|RWTO|PLE|AE|CE|FOE)
+
+#define CH390_PKT_NONE  0x00        // No packet received
+#define CH390_PKT_RDY   0x01        // Packet ready to receive
+#define CH390_PKT_ERR   0xFE        // Un-stable states mask
+
+#define BMCR_LOOPBACK   (1 << 14)   // PHY loopback bit in BMCR
+
+#define ISR_PR          (1 << 0)    // Packet received
+#define ISR_PT          (1 << 1)    // Packet transmitted
+#define ISR_ROS         (1 << 2)    // RX overflow
+#define ISR_ROO         (1 << 3)    // RX overflow counter overflow
+#define ISR_LNKCHGS     (1 << 5)    // Link status change
+#define ISR_CLR_STATUS  (ISR_LNKCHGS | ISR_ROO | ISR_ROS | ISR_PT | ISR_PR)
+
+#define IMR_PAR         (1 << 7)    // Pointer auto-return
+#define IMR_LNKCHGI     (1 << 5)    // Link change interrupt enable
+#define IMR_ROOI        (1 << 3)    // RX overflow counter overflow interrupt enable
+#define IMR_ROI         (1 << 2)    // RX overflow interrupt enable
+#define IMR_PRI         (1 << 0)    // Packet received interrupt enable
+
+#define EPCR_EPOS       (1 << 3)    // Select PHY (1) or EEPROM (0)
+#define EPCR_ERPRR      (1 << 2)    // PHY/EEPROM read command (self-clearing)
+#define EPCR_ERPRW      (1 << 1)    // PHY/EEPROM write command (self-clearing)
+#define EPCR_ERRE       (1 << 0)    // PHY/EEPROM busy flag (set during operation, auto-clears)
+
+#define INTCR_POL_LOW   (1 << 0)    // INT polarity: 1 = active low
+#define INTCR_POL_HIGH  0x00        // INT polarity: active high, push-pull
+#define INTCR_POD_OD    (1 << 1)    // INT type: 1 = open-drain, 0 = push-pull
+
+// Internal PHY register access via EPAR
+#define CH390_PHY       0x40        // PHY address for EPAR
+
+// PHY registers (accessed via EPCR/EPAR/EPDRL/EPDRH)
+#define PHY_BMCR        0x00
+#define PHY_BMSR        0x01
+#define PHY_PHYID1      0x02
+#define PHY_PHYID2      0x03
+#define PHY_ANAR        0x04
+#define PHY_ANLPAR      0x05
+
+#define BMCR_RST        (1 << 15)
+#define BMCR_ANEG_EN    (1 << 12)
+#define BMCR_ANEG_RST   (1 << 9)
+#define BMCR_SPEED100   (1 << 13)
+#define BMCR_DUPLEX     (1 << 8)
+
+#define BMSR_LINK       (1 << 2)
+#define BMSR_ANEG_DONE  (1 << 5)
+
+#define ANLPAR_100FD    (1 << 8)
+#define ANLPAR_100HD    (1 << 7)
+#define ANLPAR_10FD     (1 << 6)
+#define ANLPAR_10HD     (1 << 5)
+
+// RX packet header size (status + length)
+#define CH390_RX_HDR_SIZE   4
+
+// ---------- Public API ----------
+
+// Probe the SPI bus for a CH390D chip. Returns true if found.
+// On failure, releases SPI resources so Arduino SPI can reclaim the bus.
+bool ch390_detect(void);
+
+// Initialize Ethernet: create MAC/PHY, install driver, create netif, start DHCP.
+// Call only after ch390_detect() returned true.
+esp_err_t ch390_eth_init(void);
+
+// Get the Ethernet IP address string (empty if no IP).
+const char* ch390_get_ip(void);
+
+// Runtime flags
+extern bool EthPresent;     // true if CH390D chip was detected at boot
+extern bool EthConnected;   // true if Ethernet link is up
+extern bool EthHasIP;       // true if Ethernet interface has a DHCP IP
+
+#endif // SMARTEVSE_VERSION >= 30 && < 40
+#endif // __CH390_H

--- a/SmartEVSE-3/src/ch390.h
+++ b/SmartEVSE-3/src/ch390.h
@@ -20,8 +20,8 @@
 // Reuses LCD SPI pins. When CH390D is detected, LCD is disabled.
 #define CH390_SCK       26      // was SPI_SCK  (PIN_LCD_CLK)
 #define CH390_MOSI      33      // was SPI_MOSI (PIN_LCD_SDO_B3)
-#define CH390_MISO      25      // was PIN_LCD_A0_B2
-#define CH390_CS        14      // was PIN_LCD_LED
+#define CH390_MISO      14      // was PIN_LCD_LED
+#define CH390_CS        25      // was PIN_LCD_A0_B2
 #define CH390_INT        5      // INT pin directly connected to ESP32 GPIO5
 
 // ---------- Chip identification ----------

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -24,6 +24,7 @@ char RequiredEVCCID[32] = "";                                               // R
 
 #include <WiFi.h>
 #include "network_common.h"
+#include "ch390.h"
 #include "esp_ota_ops.h"
 #include "mbedtls/md_internal.h"
 
@@ -1580,6 +1581,23 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
             doc["wifi"]["rssi"] = WiFi.RSSI();    
             doc["wifi"]["bssid"] = WiFi.BSSIDstr();  
         }
+
+#if SMARTEVSE_VERSION >= 30 && SMARTEVSE_VERSION < 40
+        doc["eth"]["present"] = EthPresent;
+        doc["eth"]["connected"] = EthConnected;
+        doc["eth"]["has_ip"] = EthHasIP;
+        if (EthHasIP) {
+            doc["eth"]["ip"] = ch390_get_ip();
+        }
+        if (EthPresent) {
+            uint8_t eth_mac[6];
+            esp_read_mac(eth_mac, ESP_MAC_ETH);
+            char mac_str[18];
+            snprintf(mac_str, sizeof(mac_str), "%02X:%02X:%02X:%02X:%02X:%02X",
+                     eth_mac[0], eth_mac[1], eth_mac[2], eth_mac[3], eth_mac[4], eth_mac[5]);
+            doc["eth"]["mac"] = mac_str;
+        }
+#endif
         
         doc["evse"]["temp"] = TempEVSE;
         doc["evse"]["temp_max"] = maxTemp;
@@ -3077,11 +3095,11 @@ void setup() {
     pinMode(PIN_SSR2, OUTPUT);              // SSR2 output
     pinMode(PIN_RCM_FAULT, INPUT_PULLUP);   
 
-    pinMode(PIN_LCD_LED, OUTPUT);           // LCD backlight
-    pinMode(PIN_LCD_RST, OUTPUT);           // LCD reset
+    // LCD pins (14, 25, 26, 33) are NOT configured yet — they are shared with
+    // the CH390D Ethernet add-on board. Probe for CH390D first, then set up
+    // the appropriate SPI device (Ethernet or LCD).
+    pinMode(PIN_LCD_RST, INPUT);           // LCD reset now INT pin
     pinMode(PIN_IO0_B1, INPUT);             // < button
-    pinMode(PIN_LCD_A0_B2, OUTPUT);         // o Select button + A0 LCD
-    pinMode(PIN_LCD_SDO_B3, OUTPUT);        // > button + SDA/MOSI pin
 
     pinMode(PIN_LOCK_IN, INPUT);            // Locking Solenoid input
     pinMode(PIN_LEDR, OUTPUT);              // Red LED output
@@ -3101,7 +3119,6 @@ void setup() {
     digitalWrite(PIN_ACTB, LOW);        
     digitalWrite(PIN_SSR, LOW);             // SSR1 OFF
     digitalWrite(PIN_SSR2, LOW);            // SSR2 OFF
-    digitalWrite(PIN_LCD_LED, HIGH);        // LCD Backlight ON
     PILOT_DISCONNECTED;                     // CP signal OFF
 
  
@@ -3110,13 +3127,28 @@ void setup() {
     while (!Serial);
     _LOG_A("SmartEVSE v3 powerup\n");
 
-    // configure SPI connection to LCD
-    // only the SPI_SCK and SPI_MOSI pins are used
-    SPI.begin(SPI_SCK, SPI_MISO, SPI_MOSI, SPI_SS);
-    // the ST7567's max SPI Clock frequency is 20Mhz at 3.3V/25C
-    // We choose 10Mhz here, to reserve some room for error.
-    // SPI mode is MODE3 (Idle = HIGH, clock in on rising edge)
-    SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE3));
+    // Probe for CH390D Ethernet add-on board.
+    // Must run before any LCD pin setup — the shared SPI pins (14, 25, 26, 33)
+    // must be free for the IDF SPI driver to claim via the GPIO matrix.
+    if (ch390_detect()) {
+        _LOG_A("CH390D Ethernet detected, LCD disabled\n");
+        ch390_eth_init();
+    } else {
+        // No Ethernet add-on — configure shared pins for LCD use
+        pinMode(PIN_LCD_RST, OUTPUT);           // LCD reset (GPIO 5)
+        pinMode(PIN_LCD_LED, OUTPUT);           // LCD backlight (GPIO 14)
+        digitalWrite(PIN_LCD_LED, HIGH);        // LCD Backlight ON
+        pinMode(PIN_LCD_A0_B2, OUTPUT);         // o Select button + A0 LCD (GPIO 25)
+        pinMode(PIN_LCD_SDO_B3, OUTPUT);        // > button + SDA/MOSI pin (GPIO 33)
+
+        // configure SPI connection to LCD
+        // only the SPI_SCK and SPI_MOSI pins are used
+        SPI.begin(SPI_SCK, SPI_MISO, SPI_MOSI, SPI_SS);
+        // the ST7567's max SPI Clock frequency is 20Mhz at 3.3V/25C
+        // We choose 10Mhz here, to reserve some room for error.
+        // SPI mode is MODE3 (Idle = HIGH, clock in on rising edge)
+        SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE3));
+    }
     
 
     // The CP (control pilot) output is a fixed 1khz square-wave (+6..9v / -12v).
@@ -3157,7 +3189,9 @@ void setup() {
     ledcSetup(RED_CHANNEL, 5000, 8);            // R channel 2, 5kHz, 8 bit
     ledcSetup(GREEN_CHANNEL, 5000, 8);          // G channel 3, 5kHz, 8 bit
     ledcSetup(BLUE_CHANNEL, 5000, 8);           // B channel 4, 5kHz, 8 bit
-    ledcSetup(LCD_CHANNEL, 5000, 8);            // LCD channel 5, 5kHz, 8 bit
+    if (!EthPresent) {
+        ledcSetup(LCD_CHANNEL, 5000, 8);        // LCD channel 5, 5kHz, 8 bit
+    }
 
     // attach the channels to the GPIO to be controlled
     ledcAttachPin(PIN_CP_OUT, CP_CHANNEL);      
@@ -3167,13 +3201,17 @@ void setup() {
     ledcAttachPin(PIN_LEDR, RED_CHANNEL);
     ledcAttachPin(PIN_LEDG, GREEN_CHANNEL);
     ledcAttachPin(PIN_LEDB, BLUE_CHANNEL);
-    ledcAttachPin(PIN_LCD_LED, LCD_CHANNEL);
+    if (!EthPresent) {
+        ledcAttachPin(PIN_LCD_LED, LCD_CHANNEL);
+    }
 
     SetCPDuty(1024);                            // channel 0, duty cycle 100%
     ledcWrite(RED_CHANNEL, 255);
     ledcWrite(GREEN_CHANNEL, 0);
     ledcWrite(BLUE_CHANNEL, 255);
-    ledcWrite(LCD_CHANNEL, 0);
+    if (!EthPresent) {
+        ledcWrite(LCD_CHANNEL, 0);
+    }
 
     // Setup PIN interrupt on rising edge
     // the timer interrupt will be reset in the ISR.
@@ -3300,7 +3338,7 @@ extern void Timer20ms(void * parameter);
         _LOG_A("LittleFS Mount Failed\n");
     }
         
-    getButtonState();
+    if (!EthPresent) getButtonState();
 /*     * @param Buttons: < o >
  *          Value: 1 2 4
  *            Bit: 0:Pressed / 1:Released         */
@@ -3311,7 +3349,9 @@ extern void Timer20ms(void * parameter);
     }
 
     BacklightTimer = BACKLIGHT;
-    GLCD_init();
+    if (!EthPresent) {
+        GLCD_init();
+    }
 
 #if SMARTEVSE_VERSION >=40 //v4
 
@@ -3577,7 +3617,7 @@ void loop() {
 
     //OCPP lifecycle management
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
-    if (OcppMode && !getOcppContext() && WiFi.isConnected()) {
+    if (OcppMode && !getOcppContext() && NetworkConnected()) {
         ocppInit();
     } else if (!OcppMode && getOcppContext()) {
         ocppDeinit();

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -24,7 +24,6 @@ char RequiredEVCCID[32] = "";                                               // R
 
 #include <WiFi.h>
 #include "network_common.h"
-#include "ch390.h"
 #include "esp_ota_ops.h"
 #include "mbedtls/md_internal.h"
 

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -521,6 +521,15 @@ const char * getErrorNameWeb(uint8_t ErrorCode) {
 }
 
 
+void setLCDbacklight(uint8_t pwm) {
+    if (EthPresent) {
+        etherlcd_set_backlight(pwm);
+    } else {
+        ledcWrite(LCD_CHANNEL, pwm);
+    }
+}
+
+
 void getButtonState() {
     // Sample the three < o > buttons.
     // As the buttons are shared with the SPI lines going to the LCD,
@@ -531,24 +540,30 @@ void getButtonState() {
         ButtonState = ButtonStateOverride;
     else {
 #if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40
-        pinMatrixOutDetach(PIN_LCD_SDO_B3, false, false);       // disconnect MOSI pin
-        pinMode(PIN_LCD_SDO_B3, INPUT);
-        pinMode(PIN_LCD_A0_B2, INPUT);
+        if (EthPresent) {
+            // Buttons are read from CH32V003 via SPI register
+            ButtonState = etherlcd_read_buttons() & 0x07;
+        } else {
+            pinMatrixOutDetach(PIN_LCD_SDO_B3, false, false);       // disconnect MOSI pin
+            pinMode(PIN_LCD_SDO_B3, INPUT);
+            pinMode(PIN_LCD_A0_B2, INPUT);
 
-        // sample buttons                                                         < o >
-        ButtonState = (digitalRead(PIN_LCD_SDO_B3) ? 4 : 0) |  // > (right)
-                      (digitalRead(PIN_LCD_A0_B2)  ? 2 : 0) |  // o (middle)
-                      (digitalRead(PIN_IO0_B1)     ? 1 : 0);   // < (left)
+            // sample buttons                                                         < o >
+            ButtonState = (digitalRead(PIN_LCD_SDO_B3) ? 4 : 0) |  // > (right)
+                          (digitalRead(PIN_LCD_A0_B2)  ? 2 : 0) |  // o (middle)
+                          (digitalRead(PIN_IO0_B1)     ? 1 : 0);   // < (left)
 
-        pinMode(PIN_LCD_SDO_B3, OUTPUT);
-        pinMatrixOutAttach(PIN_LCD_SDO_B3, VSPID_IN_IDX, false, false); // re-attach MOSI pin
+            pinMode(PIN_LCD_SDO_B3, OUTPUT);
+            pinMatrixOutAttach(PIN_LCD_SDO_B3, VSPID_IN_IDX, false, false); // re-attach MOSI pin
+            pinMode(PIN_LCD_A0_B2, OUTPUT);                        // switch pin back to output
+        }
 #else
         pinMode(PIN_LCD_A0_B2, INPUT_PULLUP);                  // Switch the shared pin for the middle button to input
         ButtonState = (digitalRead(BUTTON3)        ? 4 : 0) |  // > (right)
                       (digitalRead(PIN_LCD_A0_B2)  ? 2 : 0) |  // o (middle)
                       (digitalRead(BUTTON1)        ? 1 : 0);   // < (left)
-#endif
         pinMode(PIN_LCD_A0_B2, OUTPUT);                        // switch pin back to output
+#endif
     }
     xSemaphoreGive(buttonMutex);
 }
@@ -3131,8 +3146,10 @@ void setup() {
     // Must run before any LCD pin setup — the shared SPI pins (14, 25, 26, 33)
     // must be free for the IDF SPI driver to claim via the GPIO matrix.
     if (ch390_detect()) {
-        _LOG_A("CH390D Ethernet detected, LCD disabled\n");
+        _LOG_A("CH390D Ethernet detected\n");
         ch390_eth_init();
+        // Ethernet+LCD board has a CH32V003 that controlls A0/RST/backlight/buttons
+        etherlcd_init();
     } else {
         // No Ethernet add-on — configure shared pins for LCD use
         pinMode(PIN_LCD_RST, OUTPUT);           // LCD reset (GPIO 5)
@@ -3191,7 +3208,7 @@ void setup() {
     ledcSetup(BLUE_CHANNEL, 5000, 8);           // B channel 4, 5kHz, 8 bit
     if (!EthPresent) {
         ledcSetup(LCD_CHANNEL, 5000, 8);        // LCD channel 5, 5kHz, 8 bit
-    }
+    }  // When EthPresent, backlight PWM is handled by CH32V003
 
     // attach the channels to the GPIO to be controlled
     ledcAttachPin(PIN_CP_OUT, CP_CHANNEL);      
@@ -3203,15 +3220,13 @@ void setup() {
     ledcAttachPin(PIN_LEDB, BLUE_CHANNEL);
     if (!EthPresent) {
         ledcAttachPin(PIN_LCD_LED, LCD_CHANNEL);
-    }
+    }  // When EthPresent, PIN_LCD_LED is used as ETH_CS
 
     SetCPDuty(1024);                            // channel 0, duty cycle 100%
     ledcWrite(RED_CHANNEL, 255);
     ledcWrite(GREEN_CHANNEL, 0);
     ledcWrite(BLUE_CHANNEL, 255);
-    if (!EthPresent) {
-        ledcWrite(LCD_CHANNEL, 0);
-    }
+    setLCDbacklight(0);
 
     // Setup PIN interrupt on rising edge
     // the timer interrupt will be reset in the ISR.
@@ -3338,7 +3353,7 @@ extern void Timer20ms(void * parameter);
         _LOG_A("LittleFS Mount Failed\n");
     }
         
-    if (!EthPresent) getButtonState();
+    getButtonState();
 /*     * @param Buttons: < o >
  *          Value: 1 2 4
  *            Bit: 0:Pressed / 1:Released         */
@@ -3349,9 +3364,8 @@ extern void Timer20ms(void * parameter);
     }
 
     BacklightTimer = BACKLIGHT;
-    if (!EthPresent) {
-        GLCD_init();
-    }
+    GLCD_init();
+ 
 
 #if SMARTEVSE_VERSION >=40 //v4
 

--- a/SmartEVSE-3/src/esp32.h
+++ b/SmartEVSE-3/src/esp32.h
@@ -67,6 +67,8 @@
 #define SPI_SCK 26
 #define SPI_SS -1
 
+#include "ch390.h"                                                              // CH390D SPI Ethernet (add-on board)
+
 #define CP_CHANNEL 0
 #define RED_CHANNEL 2                                                           // PWM channel 2 (0 and 1 are used by CP signal)
 #define GREEN_CHANNEL 3

--- a/SmartEVSE-3/src/esp32.h
+++ b/SmartEVSE-3/src/esp32.h
@@ -68,6 +68,7 @@
 #define SPI_SS -1
 
 #include "ch390.h"                                                              // CH390D SPI Ethernet (add-on board)
+#include "etherlcd.h"                                                           // CH32V003 Ethernet+LCD board interface
 
 #define CP_CHANNEL 0
 #define RED_CHANNEL 2                                                           // PWM channel 2 (0 and 1 are used by CP signal)
@@ -89,10 +90,12 @@
 #define PIN_EXT_V31 13
 #define PIN_BUZZER_V31 18
 
-#define _RSTB_0 digitalWrite(PIN_LCD_RST, LOW);
-#define _RSTB_1 digitalWrite(PIN_LCD_RST, HIGH);
-#define _A0_0 digitalWrite(PIN_LCD_A0_B2, LOW);
-#define _A0_1 digitalWrite(PIN_LCD_A0_B2, HIGH);
+// LCD control line macros — route through CH32V003 when Ethernet board is present,
+// otherwise fall back to direct GPIO.
+#define _RSTB_0 do { if (EthPresent) etherlcd_lcd_rst(false); else digitalWrite(PIN_LCD_RST, LOW); } while(0)
+#define _RSTB_1 do { if (EthPresent) etherlcd_lcd_rst(true);  else digitalWrite(PIN_LCD_RST, HIGH); } while(0)
+#define _A0_0   do { if (EthPresent) etherlcd_lcd_a0(false);  else digitalWrite(PIN_LCD_A0_B2, LOW); } while(0)
+#define _A0_1   do { if (EthPresent) etherlcd_lcd_a0(true);   else digitalWrite(PIN_LCD_A0_B2, HIGH); } while(0)
 
 extern portMUX_TYPE rtc_spinlock;   //TODO: Will be placed in the appropriate position after the rtc module is finished.
 

--- a/SmartEVSE-3/src/esp32.h
+++ b/SmartEVSE-3/src/esp32.h
@@ -67,7 +67,6 @@
 #define SPI_SCK 26
 #define SPI_SS -1
 
-#include "ch390.h"                                                              // CH390D SPI Ethernet (add-on board)
 #include "etherlcd.h"                                                           // CH32V003 Ethernet+LCD board interface
 
 #define CP_CHANNEL 0

--- a/SmartEVSE-3/src/etherlcd.cpp
+++ b/SmartEVSE-3/src/etherlcd.cpp
@@ -1,0 +1,177 @@
+/*
+ * EtherLCD — CH32V003 interface for the Ethernet+LCD add-on board.
+ *
+ * ESP32 communicates with the CH32V003 using the same SPI bus as the CH390D
+ * Ethernet chip. The CH32V003 enters local-select mode when both CS lines
+ * (ETH_CS and LCD_CS) are idle (high) — i.e. when neither the Ethernet chip
+ * nor the LCD is being addressed.
+ *
+ * A dedicated IDF SPI device with spics_io_num=-1 (no hardware CS) is used
+ * for CH32V003 register access. Every transaction is preceded by a magic
+ * byte (0xEB) so the CH32V003 can distinguish real commands from stale SPI
+ * data left over from ETH/LCD transfers.
+ *
+ * The LCD is addressed via a separate IDF SPI device with CS=GPIO0 (LCD_CS).
+ * The CH32V003 sees LCD_CS go low and forwards it to the LCD's SCS pin.
+ */
+
+#include <Arduino.h>
+
+#if SMARTEVSE_VERSION >= 30 && SMARTEVSE_VERSION < 40
+
+#include "debug.h"
+#include "etherlcd.h"
+#include "driver/spi_master.h"
+#include "driver/gpio.h"
+
+// Magic byte that must precede every CH32V003 register command.
+#define ELCD_SPI_MAGIC  0xEBu
+
+// SPI device handle for the LCD (CS = GPIO0, mode 3, 10 MHz).
+static spi_device_handle_t s_lcd_spi = NULL;
+
+// SPI device handle for CH32V003 register access (no CS, mode 3, 10 MHz).
+static spi_device_handle_t s_ch32_spi = NULL;
+
+// Cached LCD_CTL register state to avoid read-modify-write round trips.
+static uint8_t s_lcd_ctl = ELCD_CTL_SCS | ELCD_CTL_RST;   // SCS=1 RST=1 A0=0
+
+void etherlcd_init(void) {
+    // LCD_CS (GPIO0) is a new output for the Ethernet+LCD board.
+    gpio_set_direction((gpio_num_t)ELCD_LCD_CS_PIN, GPIO_MODE_OUTPUT);
+    gpio_set_level((gpio_num_t)ELCD_LCD_CS_PIN, 1);
+
+    // Add LCD SPI device on the same bus.
+    // CS = GPIO0 (LCD_CS). The CH32V003 sees LCD_CS low and forwards it
+    // to the LCD's SCS output via passthrough.
+    spi_device_interface_config_t lcd_dev = {};
+    lcd_dev.command_bits = 0;
+    lcd_dev.address_bits = 0;
+    lcd_dev.mode = 3;                       // CPOL=1 CPHA=1 — ST7567 mode 3
+    lcd_dev.clock_speed_hz = 10000000;      // 10 MHz
+    lcd_dev.spics_io_num = ELCD_LCD_CS_PIN; // CS = GPIO0
+    lcd_dev.queue_size = 1;
+    lcd_dev.flags = SPI_DEVICE_HALFDUPLEX;
+
+    esp_err_t ret = spi_bus_add_device(SPI3_HOST, &lcd_dev, &s_lcd_spi);
+    if (ret != ESP_OK) {
+        _LOG_A("EtherLCD: LCD SPI device add failed: %s\n", esp_err_to_name(ret));
+        return;
+    }
+
+    // Add CH32V003 register-access SPI device on the same bus.
+    // No CS pin — both CS lines stay high, which is the CH32V003 local-select condition.
+    spi_device_interface_config_t ch32_dev = {};
+    ch32_dev.command_bits = 0;
+    ch32_dev.address_bits = 0;
+    ch32_dev.mode = 3;
+    ch32_dev.clock_speed_hz = 10000000;
+    ch32_dev.spics_io_num = -1;             // no hardware CS
+    ch32_dev.queue_size = 1;
+    ch32_dev.flags = SPI_DEVICE_HALFDUPLEX;
+
+    ret = spi_bus_add_device(SPI3_HOST, &ch32_dev, &s_ch32_spi);
+    if (ret != ESP_OK) {
+        _LOG_A("EtherLCD: CH32 SPI device add failed: %s\n", esp_err_to_name(ret));
+        return;
+    }
+
+    // Initialise CH32V003 registers to sane defaults.
+    etherlcd_reg_write(ELCD_REG_LCD_CTL, ELCD_CTL_SCS | ELCD_CTL_RST);
+    etherlcd_set_backlight(128);
+
+    _LOG_A("EtherLCD: CH32V003 interface initialised\n");
+}
+
+uint8_t etherlcd_reg_read(uint8_t reg) {
+    // Acquire the bus so no CH390/LCD transaction can overlap.
+    spi_device_acquire_bus(s_ch32_spi, portMAX_DELAY);
+
+    // Byte 1: magic. Byte 2: read command (0x80 | reg).
+    spi_transaction_t t1 = {};
+    t1.flags = SPI_TRANS_USE_TXDATA;
+    t1.length = 16;
+    t1.tx_data[0] = ELCD_SPI_MAGIC;
+    t1.tx_data[1] = 0x80u | (reg & 0x7Fu);
+    spi_device_polling_transmit(s_ch32_spi, &t1);
+
+    // Clock in one byte response (read-only).
+    spi_transaction_t t2 = {};
+    t2.flags = SPI_TRANS_USE_RXDATA;
+    t2.rxlength = 8;
+    spi_device_polling_transmit(s_ch32_spi, &t2);
+
+    spi_device_release_bus(s_ch32_spi);
+    return t2.rx_data[0];
+}
+
+void etherlcd_reg_write(uint8_t reg, uint8_t value) {
+    spi_device_acquire_bus(s_ch32_spi, portMAX_DELAY);
+
+    // Magic + register address + value in one 3-byte TX-only transaction.
+    spi_transaction_t t = {};
+    t.flags = SPI_TRANS_USE_TXDATA;
+    t.length = 24;
+    t.tx_data[0] = ELCD_SPI_MAGIC;
+    t.tx_data[1] = reg & 0x7Fu;
+    t.tx_data[2] = value;
+    spi_device_polling_transmit(s_ch32_spi, &t);
+
+    spi_device_release_bus(s_ch32_spi);
+}
+
+uint8_t etherlcd_read_buttons(void) {
+    return etherlcd_reg_read(ELCD_REG_BUTTONS);
+}
+
+void etherlcd_set_backlight(uint8_t pwm) {
+    etherlcd_reg_write(ELCD_REG_LED_PWM, pwm);
+}
+
+void etherlcd_lcd_a0(bool high) {
+    uint8_t new_ctl = s_lcd_ctl;
+    if (high)
+        new_ctl |= ELCD_CTL_A0;
+    else
+        new_ctl &= ~ELCD_CTL_A0;
+    if (new_ctl != s_lcd_ctl) {
+        s_lcd_ctl = new_ctl;
+        etherlcd_reg_write(ELCD_REG_LCD_CTL, s_lcd_ctl);
+    }
+}
+
+void etherlcd_lcd_rst(bool high) {
+    if (high)
+        s_lcd_ctl |= ELCD_CTL_RST;
+    else
+        s_lcd_ctl &= ~ELCD_CTL_RST;
+    etherlcd_reg_write(ELCD_REG_LCD_CTL, s_lcd_ctl);
+}
+
+void etherlcd_lcd_transfer(uint8_t data) {
+    spi_transaction_t t = {};
+    t.flags = SPI_TRANS_USE_TXDATA;
+    t.length = 8;
+    t.tx_data[0] = data;
+    spi_device_polling_transmit(s_lcd_spi, &t);
+}
+
+void etherlcd_lcd_transfer_buf(const uint8_t *data, size_t len) {
+    if (len == 0) return;
+    spi_transaction_t t = {};
+    t.length = len * 8;
+    t.tx_buffer = data;
+    spi_device_polling_transmit(s_lcd_spi, &t);
+}
+
+void etherlcd_lcd_command(uint8_t cmd) {
+    etherlcd_lcd_a0(false);
+    etherlcd_lcd_transfer(cmd);
+}
+
+void etherlcd_lcd_data(uint8_t data) {
+    etherlcd_lcd_a0(true);
+    etherlcd_lcd_transfer(data);
+}
+
+#endif // SMARTEVSE_VERSION >= 30 && < 40

--- a/SmartEVSE-3/src/etherlcd.cpp
+++ b/SmartEVSE-3/src/etherlcd.cpp
@@ -1,10 +1,41 @@
 /*
  * EtherLCD — CH32V003 interface for the Ethernet+LCD add-on board.
  *
+ * The Ethernet+LCD board reuses all six original LCD/button GPIO pins for
+ * SPI communication with the CH390D Ethernet chip. A CH32V003 on the
+ * add-on board takes over the LCD control and button reading functions
+ * that were previously handled by direct GPIO on the ESP32.
+ *
+ * Pin reuse (original SmartEVSE v3 → Ethernet+LCD board):
+ *
+ *   GPIO  Original function             New function
+ *   ----  ----------------------------  -----------------------
+ *    33   PIN_LCD_SDO_B3 (MOSI / B3)    CH390_MOSI  (SPI MOSI)
+ *     5   PIN_LCD_RST    (LCD reset)    CH390_INT   (ETH interrupt)
+ *    25   PIN_LCD_A0_B2  (A0 / B2)      CH390_CS    (ETH chip select)
+ *    26   PIN_LCD_CLK    (SPI clock)    CH390_SCK   (SPI clock)
+ *     0   PIN_IO0_B1     (boot / B1)    LCD_CS      (LCD chip select)
+ *    14   PIN_LCD_LED    (backlight)    CH390_MISO  (SPI MISO)
+ *
+ * Functions moved to CH32V003 registers:
+ *   - Button 1      (was GPIO0)         → REG_BUTTONS  (0x00) bit0
+ *   - Button 2      (was GPIO25)        → REG_BUTTONS  (0x00) bit1
+ *   - Button 3      (was GPIO33)        → REG_BUTTONS  (0x00) bit2
+ *   - LCD backlight (was PWM on GPIO14) → REG_LED_PWM  (0x01)
+ *   - LCD RST       (was GPIO5)         → REG_LCD_CTL  (0x02) bit1
+ *   - LCD A0        (was GPIO25)        → REG_LCD_CTL  (0x02) bit2
+ *   - ETH RST       (PD4 on CH32V003)   → REG_ETH_RST  (0x03) bit0
+ *
+ * The original v3 code read buttons by temporarily switching the shared
+ * LCD pins (GPIO0, GPIO25, GPIO33) to inputs. With the Ethernet+LCD
+ * board, buttons are standalone inputs on the CH32V003 (PC2–PC4) and
+ * are always readable via a single SPI register read.
+ *
  * ESP32 communicates with the CH32V003 using the same SPI bus as the CH390D
- * Ethernet chip. The CH32V003 enters local-select mode when both CS lines
- * (ETH_CS and LCD_CS) are idle (high) — i.e. when neither the Ethernet chip
- * nor the LCD is being addressed.
+ * and the LCD. The CS lines go directly from the ESP32 to the CH390D and
+ * LCD; the CH32V003 monitors them on PD1 (LCD_CS) and PD2 (ETH_CS). When
+ * both CS lines are idle (high), the CH32V003 enters local-select mode
+ * for register access.
  *
  * A dedicated IDF SPI device with spics_io_num=-1 (no hardware CS) is used
  * for CH32V003 register access. Every transaction is preceded by a magic
@@ -12,7 +43,6 @@
  * data left over from ETH/LCD transfers.
  *
  * The LCD is addressed via a separate IDF SPI device with CS=GPIO0 (LCD_CS).
- * The CH32V003 sees LCD_CS go low and forwards it to the LCD's SCS pin.
  */
 
 #include <Arduino.h>
@@ -27,10 +57,10 @@
 // Magic byte that must precede every CH32V003 register command.
 #define ELCD_SPI_MAGIC  0xEBu
 
-// SPI device handle for the LCD (CS = GPIO0, mode 3, 10 MHz).
+// SPI device handle for the LCD (CS = GPIO0, mode 3, 12 MHz).
 static spi_device_handle_t s_lcd_spi = NULL;
 
-// SPI device handle for CH32V003 register access (no CS, mode 3, 10 MHz).
+// SPI device handle for CH32V003 register access (no CS, mode 3, 12 MHz).
 static spi_device_handle_t s_ch32_spi = NULL;
 
 // Cached LCD_CTL register state to avoid read-modify-write round trips.
@@ -42,13 +72,12 @@ void etherlcd_init(void) {
     gpio_set_level((gpio_num_t)ELCD_LCD_CS_PIN, 1);
 
     // Add LCD SPI device on the same bus.
-    // CS = GPIO0 (LCD_CS). The CH32V003 sees LCD_CS low and forwards it
-    // to the LCD's SCS output via passthrough.
+    // CS = GPIO0 (LCD_CS).  This directly selects the LCD on the add-on board.
     spi_device_interface_config_t lcd_dev = {};
     lcd_dev.command_bits = 0;
     lcd_dev.address_bits = 0;
     lcd_dev.mode = 3;                       // CPOL=1 CPHA=1 — ST7567 mode 3
-    lcd_dev.clock_speed_hz = 10000000;      // 10 MHz
+    lcd_dev.clock_speed_hz = 12000000;      // 12 MHz
     lcd_dev.spics_io_num = ELCD_LCD_CS_PIN; // CS = GPIO0
     lcd_dev.queue_size = 1;
     lcd_dev.flags = SPI_DEVICE_HALFDUPLEX;
@@ -65,7 +94,7 @@ void etherlcd_init(void) {
     ch32_dev.command_bits = 0;
     ch32_dev.address_bits = 0;
     ch32_dev.mode = 3;
-    ch32_dev.clock_speed_hz = 10000000;
+    ch32_dev.clock_speed_hz = 12000000;     // 12 MHz
     ch32_dev.spics_io_num = -1;             // no hardware CS
     ch32_dev.queue_size = 1;
     ch32_dev.flags = SPI_DEVICE_HALFDUPLEX;
@@ -174,4 +203,7 @@ void etherlcd_lcd_data(uint8_t data) {
     etherlcd_lcd_transfer(data);
 }
 
+void etherlcd_eth_rst(bool active) {
+    etherlcd_reg_write(ELCD_REG_ETH_RST, active ? 1 : 0);
+}
 #endif // SMARTEVSE_VERSION >= 30 && < 40

--- a/SmartEVSE-3/src/etherlcd.h
+++ b/SmartEVSE-3/src/etherlcd.h
@@ -1,0 +1,77 @@
+/*
+ * EtherLCD — Interface to the CH32V003 on the Ethernet+LCD add-on board.
+ *
+ * The CH32V003 sits between the ESP32 and the LCD/Ethernet peripherals.
+ * It forwards chip-select signals (ETH_CS→ETH_SCS, LCD_CS→LCD_SCS).
+ * When both CS lines are idle (high) — i.e. neither the Ethernet chip
+ * nor the LCD is being addressed — the CH32V003 enters local-select
+ * mode for SPI register access.
+ *
+ * A magic byte (0xEB) precedes every register command to protect against
+ * stale SPI data from ETH/LCD transfers being misinterpreted.
+ *
+ *   REG 0x00  BUTTONS   (RO)  bit0=B1, bit1=B2, bit2=B3, 0=pressed
+ *   REG 0x01  LED_PWM   (RW)  0..255 backlight brightness
+ *   REG 0x02  LCD_CTL   (RW)  bit0=SCS bit1=RST bit2=A0
+ *
+ * SPI protocol (mode 3, CPOL=1 CPHA=1):
+ *   Read:  TX: 0xEB, 0x80|reg, dummy → RX byte3 = value
+ *   Write: TX: 0xEB, reg, value
+ */
+
+#ifndef __ETHERLCD_H
+#define __ETHERLCD_H
+
+#include <Arduino.h>
+
+#if SMARTEVSE_VERSION >= 30 && SMARTEVSE_VERSION < 40
+
+// CH32V003 register addresses (match EtherLCD firmware)
+#define ELCD_REG_BUTTONS    0x00
+#define ELCD_REG_LED_PWM    0x01
+#define ELCD_REG_LCD_CTL    0x02
+
+// LCD_CTL register bits
+#define ELCD_CTL_SCS        (1u << 0)
+#define ELCD_CTL_RST        (1u << 1)
+#define ELCD_CTL_A0         (1u << 2)
+
+// Pin reuse: on the Ethernet+LCD board these ESP32 GPIOs become chip selects
+// that the CH32V003 monitors.
+#define ELCD_ETH_CS_PIN     14      // was PIN_LCD_LED,    now ETH_CS
+#define ELCD_LCD_CS_PIN      0      // was PIN_IO0_B1,     now LCD_CS
+
+// Initialize SPI devices for LCD and CH32V003 on the shared bus.
+// Call after ch390_detect() succeeds and the SPI bus is already initialized.
+void etherlcd_init(void);
+
+// Read a CH32V003 register (asserts both CS lines).
+uint8_t etherlcd_reg_read(uint8_t reg);
+
+// Write a CH32V003 register (asserts both CS lines).
+void etherlcd_reg_write(uint8_t reg, uint8_t value);
+
+// Write button state from CH32V003 into the passed-in variable.
+uint8_t etherlcd_read_buttons(void);
+
+// Set LCD backlight brightness (0..255) via CH32V003 PWM.
+void etherlcd_set_backlight(uint8_t pwm);
+
+// Set LCD control lines (A0, RST) via CH32V003.
+void etherlcd_lcd_a0(bool high);
+void etherlcd_lcd_rst(bool high);
+
+// Transfer a byte to the LCD via dedicated LCD SPI device (uses LCD_CS on GPIO0).
+void etherlcd_lcd_transfer(uint8_t data);
+
+// Transfer a buffer of bytes to the LCD in one SPI transaction.
+void etherlcd_lcd_transfer_buf(const uint8_t *data, size_t len);
+
+// Send a command byte to the LCD (A0=0, CS toggle, SPI transfer).
+void etherlcd_lcd_command(uint8_t cmd);
+
+// Send a data byte to the LCD (A0=1, CS toggle, SPI transfer).
+void etherlcd_lcd_data(uint8_t data);
+
+#endif // SMARTEVSE_VERSION >= 30 && < 40
+#endif // __ETHERLCD_H

--- a/SmartEVSE-3/src/etherlcd.h
+++ b/SmartEVSE-3/src/etherlcd.h
@@ -1,11 +1,17 @@
 /*
  * EtherLCD — Interface to the CH32V003 on the Ethernet+LCD add-on board.
  *
- * The CH32V003 sits between the ESP32 and the LCD/Ethernet peripherals.
- * It forwards chip-select signals (ETH_CS→ETH_SCS, LCD_CS→LCD_SCS).
- * When both CS lines are idle (high) — i.e. neither the Ethernet chip
- * nor the LCD is being addressed — the CH32V003 enters local-select
- * mode for SPI register access.
+ * The add-on board reuses the six ESP32 LCD/button GPIOs for SPI
+ * communication with the CH390D Ethernet chip.  The CH32V003 replaces
+ * the direct GPIO functions that are no longer available:
+ *
+ *   - LCD backlight, RST, A0 → REG_LCD_CTL / REG_LED_PWM registers
+ *   - Buttons 1–3 (were shared with LCD pins) → REG_BUTTONS register
+ *
+ * The CS lines go directly from the ESP32 to the peripherals; the
+ * CH32V003 monitors them on PD1 (LCD_CS) and PD2 (ETH_CS).  When both
+ * are idle (high), the CH32V003 enters local-select mode for register
+ * access.
  *
  * A magic byte (0xEB) precedes every register command to protect against
  * stale SPI data from ETH/LCD transfers being misinterpreted.
@@ -13,6 +19,7 @@
  *   REG 0x00  BUTTONS   (RO)  bit0=B1, bit1=B2, bit2=B3, 0=pressed
  *   REG 0x01  LED_PWM   (RW)  0..255 backlight brightness
  *   REG 0x02  LCD_CTL   (RW)  bit0=SCS bit1=RST bit2=A0
+ *   REG 0x03  ETH_RST   (RW)  bit0=RST (1=active/low, 0=inactive/high)
  *
  * SPI protocol (mode 3, CPOL=1 CPHA=1):
  *   Read:  TX: 0xEB, 0x80|reg, dummy → RX byte3 = value
@@ -30,6 +37,7 @@
 #define ELCD_REG_BUTTONS    0x00
 #define ELCD_REG_LED_PWM    0x01
 #define ELCD_REG_LCD_CTL    0x02
+#define ELCD_REG_ETH_RST    0x03
 
 // LCD_CTL register bits
 #define ELCD_CTL_SCS        (1u << 0)
@@ -38,7 +46,7 @@
 
 // Pin reuse: on the Ethernet+LCD board these ESP32 GPIOs become chip selects
 // that the CH32V003 monitors.
-#define ELCD_ETH_CS_PIN     14      // was PIN_LCD_LED,    now ETH_CS
+#define ELCD_ETH_CS_PIN     25      // was PIN_LCD_A0_B2,  now ETH_CS
 #define ELCD_LCD_CS_PIN      0      // was PIN_IO0_B1,     now LCD_CS
 
 // Initialize SPI devices for LCD and CH32V003 on the shared bus.
@@ -72,6 +80,10 @@ void etherlcd_lcd_command(uint8_t cmd);
 
 // Send a data byte to the LCD (A0=1, CS toggle, SPI transfer).
 void etherlcd_lcd_data(uint8_t data);
+
+// Assert or release Ethernet chip (CH390D) hardware reset via CH32V003.
+// active=true pulls ETH_RST low (reset), active=false releases it high.
+void etherlcd_eth_rst(bool active);
 
 #endif // SMARTEVSE_VERSION >= 30 && < 40
 #endif // __ETHERLCD_H

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -32,7 +32,6 @@
 #include "utils.h"
 #include "meter.h"
 #include "network_common.h"
-#include "ch390.h"
 #include "font.cpp"
 #include "font2.cpp"
 

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -422,6 +422,9 @@ unsigned char MenuNavCharArray(unsigned char Buttons, unsigned char Value, unsig
 // uses buffer
 void GLCDHelp(void)                                                             // Display/Scroll helptext on LCD 
 {
+#if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40
+  if (EthPresent) return;                                                       // SPI bus used by Ethernet
+#endif
   if (ScrollTimer + 5000 < millis()) {
     unsigned int x = strlen(MenuStr[LCDNav].Desc);
     GLCD_print_buf2_left(MenuStr[LCDNav].Desc + LCDpos);
@@ -437,6 +440,9 @@ void GLCDHelp(void)                                                             
 
 // called once a second
 void GLCD(void) {
+#if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40
+    if (EthPresent) return;                                                     // SPI bus used by Ethernet
+#endif
     unsigned char x;
     unsigned int seconds, minutes;
     static unsigned char energy_mains = 20; // X position
@@ -1210,6 +1216,9 @@ uint8_t getMenuItems (void) {
  *            Bit: 0:Pressed / 1:Released
  */
 void GLCDMenu(uint8_t Buttons) {
+#if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40
+    if (EthPresent) return;                                                     // SPI bus used by Ethernet
+#endif
     static unsigned long ButtonTimer = 0;
     static uint8_t ButtonRelease = 0;                                           // keeps track of LCD Menu Navigation
     static uint16_t value, ButtonRepeat = 0;
@@ -1435,6 +1444,7 @@ void GLCDMenu(uint8_t Buttons) {
 
 void GLCD_init(void) {
 #if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40
+    if (EthPresent) return;                                                     // SPI bus used by Ethernet
     delay(200);                                                                 // transients on the line could have garbled the LCD, wait 200ms then re-init.
 #endif
     _A0_0;                                                                      // A0=0

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -98,12 +98,29 @@ extern uint8_t RCMTestCounter;
 
 void st7565_command(unsigned char data) {
     _A0_0;
-    SPI.transfer(data);
+    if (EthPresent) {
+        etherlcd_lcd_transfer(data);
+    } else {
+        SPI.transfer(data);
+    }
 }
 
 void st7565_data(unsigned char data) {
     _A0_1;
-    SPI.transfer(data);
+    if (EthPresent) {
+        etherlcd_lcd_transfer(data);
+    } else {
+        SPI.transfer(data);
+    }
+}
+
+void st7565_data_buf(const uint8_t *buf, size_t len) {
+    _A0_1;
+    if (EthPresent) {
+        etherlcd_lcd_transfer_buf(buf, len);
+    } else {
+        SPI.writeBytes(buf, len);
+    }
 }
 #else //SMARTEVSE_VERSION
 
@@ -118,6 +135,13 @@ void st7565_data(unsigned char data) {
     _A0_1;
     digitalWrite(LCD_CS, LOW);
     LCD_SPI2.transfer(data);
+    digitalWrite(LCD_CS, HIGH);
+}
+
+void st7565_data_buf(const uint8_t *buf, size_t len) {
+    _A0_1;
+    digitalWrite(LCD_CS, LOW);
+    LCD_SPI2.writeBytes(buf, len);
     digitalWrite(LCD_CS, HIGH);
 }
 #endif //SMARTEVSE_VERSION
@@ -145,13 +169,11 @@ void goto_xy(unsigned char x, unsigned char y) {
 }
 
 void glcd_clrln(unsigned char ln, unsigned char data) {
-    unsigned char i;
+    uint8_t linebuf[128];
+    memset(linebuf, data, 128);
     goto_xy(0, ln);
-    for (i = 0; i < 128; i++) {
-        st7565_data(data);                                                      // put data on data port
-        // Also update the buffer that mirrors the LCD.
-        GLCDbuf2[i + activeRow * 128] = data;
-    }
+    st7565_data_buf(linebuf, 128);
+    memcpy(&GLCDbuf2[activeRow * 128], linebuf, 128);
 }
 
 /*
@@ -178,17 +200,15 @@ void GLCD_buffer_clr(void) {
 }
 
 void GLCD_sendbuf(unsigned char RowAdr, unsigned char Rows) {
-    unsigned char i, y = 0;
+    unsigned char y = 0;
     unsigned int x = 0;
 
     do {
         goto_xy(0, RowAdr + y);
-        // Sends one chunk of 8 pixels height and 128 pixels wide.
-        for (i = 0; i < 128; i++) {
-            const uint8_t data = GLCDbuf[x++];
-            st7565_data(data);                                              // put data on data port
-            GLCDbuf2[i + activeRow * 128] = data;                           // Also update buffer copy
-        }
+        // Send entire 128-byte row in one bulk SPI transfer.
+        st7565_data_buf(&GLCDbuf[x], 128);
+        memcpy(&GLCDbuf2[activeRow * 128], &GLCDbuf[x], 128);              // Also update buffer copy
+        x += 128;
     } while (++y < Rows);
 }
 
@@ -422,9 +442,6 @@ unsigned char MenuNavCharArray(unsigned char Buttons, unsigned char Value, unsig
 // uses buffer
 void GLCDHelp(void)                                                             // Display/Scroll helptext on LCD 
 {
-#if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40
-  if (EthPresent) return;                                                       // SPI bus used by Ethernet
-#endif
   if (ScrollTimer + 5000 < millis()) {
     unsigned int x = strlen(MenuStr[LCDNav].Desc);
     GLCD_print_buf2_left(MenuStr[LCDNav].Desc + LCDpos);
@@ -440,9 +457,6 @@ void GLCDHelp(void)                                                             
 
 // called once a second
 void GLCD(void) {
-#if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40
-    if (EthPresent) return;                                                     // SPI bus used by Ethernet
-#endif
     unsigned char x;
     unsigned int seconds, minutes;
     static unsigned char energy_mains = 20; // X position
@@ -1216,9 +1230,6 @@ uint8_t getMenuItems (void) {
  *            Bit: 0:Pressed / 1:Released
  */
 void GLCDMenu(uint8_t Buttons) {
-#if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40
-    if (EthPresent) return;                                                     // SPI bus used by Ethernet
-#endif
     static unsigned long ButtonTimer = 0;
     static uint8_t ButtonRelease = 0;                                           // keeps track of LCD Menu Navigation
     static uint16_t value, ButtonRepeat = 0;
@@ -1444,7 +1455,6 @@ void GLCDMenu(uint8_t Buttons) {
 
 void GLCD_init(void) {
 #if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40
-    if (EthPresent) return;                                                     // SPI bus used by Ethernet
     delay(200);                                                                 // transients on the line could have garbled the LCD, wait 200ms then re-init.
 #endif
     _A0_0;                                                                      // A0=0

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -32,6 +32,7 @@
 #include "utils.h"
 #include "meter.h"
 #include "network_common.h"
+#include "ch390.h"
 #include "font.cpp"
 #include "font2.cpp"
 
@@ -219,7 +220,10 @@ void GLCD_font_condense(unsigned char c, unsigned char *start, unsigned char *en
         if(font[c][1] == 0) *start = 2;
         else *start = 1;
     }
-    if(font[c][4] == 0) *end = 4;
+    if(font[c][4] == 0) {
+        if(font[c][3] == 0) *end = 3;
+        else *end = 4;
+    }
 }
 
 unsigned char GLCD_text_length(const char *str) {
@@ -513,9 +517,19 @@ void GLCD(void) {
             if (MQTTclientSmartEVSE.connected) GLCD_write_buf_str(0, 0, "Connected to server", GLCD_ALIGN_LEFT);
             else GLCD_write_buf_str(0, 0, "No server connection", GLCD_ALIGN_LEFT);
         } else {
-            // When connected to Wifi, display IP and time in top row
+            // Display IP and time in top row (Ethernet takes priority over WiFi)
             uint8_t WIFImode = getItemValue(MENU_WIFI);
-            if (WIFImode == 1 ) {   // Wifi Enabled
+            if (EthHasIP) {
+                if (LCDNav == MENU_WIFI && WIFImode != 0) {
+                    GLCD_write_buf_str(0,0, "Disconnect Eth first", GLCD_ALIGN_LEFT);
+                } else {
+                    sprintf(Str, "%s", ch390_get_ip());
+                    GLCD_write_buf_str(0,0, Str, GLCD_ALIGN_LEFT);
+                    if (LocalTimeSet) sprintf(Str, "%02u:%02u",timeinfo.tm_hour, timeinfo.tm_min);
+                    else sprintf(Str, "--:--");
+                    GLCD_write_buf_str(127,0, Str, GLCD_ALIGN_RIGHT);
+                }
+            } else if (WIFImode == 1 ) {   // Wifi Enabled
 
                 if (WiFi.status() == WL_CONNECTED) {
                     sprintf(Str, "%s",WiFi.localIP().toString().c_str());

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -3045,7 +3045,7 @@ void Timer10ms_singlerun(void) {
 // Task that handles EVSE State Changes
 // Reads buttons, and updates the LCD.
     static uint16_t old_sec = 0;
-    getButtonState();
+    if (!EthPresent) getButtonState();
 
     // When one or more button(s) are pressed, we call GLCDMenu
     if (((ButtonState != 0x07) || (ButtonState != OldButtonState)) ) {
@@ -3628,7 +3628,7 @@ int16_t getBatteryCurrent(void) {
         homeBatteryLastUpdate = 0;                      // last update was more then 60s ago, set to 0
         homeBatteryCurrent = 0;
         return 0;
-    } else if (Mode == MODE_SOLAR) {
+    } else if (Mode == MODE_SOLAR) {                    // Use BatteryCurrent only in Solar Mode
         return homeBatteryCurrent;
     } else {
         return 0;                                       // don't touch homeBatteryCurrent, just return 0

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -3027,25 +3027,25 @@ void Timer10ms_singlerun(void) {
     if (BacklightTimer > 1 && BacklightSet != 1) {                      // Enable LCD backlight at max brightness
                                                                         // start only when fully off(0) or when we are dimming the backlight(2)
         LcdPwm = LCD_BRIGHTNESS;
-        ledcWrite(LCD_CHANNEL, LcdPwm);
+        setLCDbacklight(LcdPwm);
         BacklightSet = 1;                                               // 1: we have set the backlight to max brightness
     }
 
     if (BacklightTimer == 1 && LcdPwm >= 3) {                           // Last second of Backlight
         LcdPwm -= 3;
-        ledcWrite(LCD_CHANNEL, ease8InOutQuad(LcdPwm));                 // fade out
+        setLCDbacklight(ease8InOutQuad(LcdPwm));                        // fade out
         BacklightSet = 2;                                               // 2: we are dimming the backlight
     }
                                                                         // Note: could be simplified by removing following code if LCD_BRIGHTNESS is multiple of 3
     if (BacklightTimer == 0 && BacklightSet) {                          // End of LCD backlight
-        ledcWrite(LCD_CHANNEL, 0);                                      // switch off LED PWM
+        setLCDbacklight(0);                                             // switch off LED PWM
         BacklightSet = 0;                                               // 0: backlight fully off
     }
 
 // Task that handles EVSE State Changes
 // Reads buttons, and updates the LCD.
     static uint16_t old_sec = 0;
-    if (!EthPresent) getButtonState();
+    getButtonState();
 
     // When one or more button(s) are pressed, we call GLCDMenu
     if (((ButtonState != 0x07) || (ButtonState != OldButtonState)) ) {

--- a/SmartEVSE-3/src/main.h
+++ b/SmartEVSE-3/src/main.h
@@ -154,10 +154,12 @@
 #define PILOT_NOK   0
 #define PILOT_SHORT 255
 
+#ifndef SMARTEVSE_VERSION
 #define _RSTB_0 digitalWrite(PIN_LCD_RST, LOW);
 #define _RSTB_1 digitalWrite(PIN_LCD_RST, HIGH);
 #define _A0_0 digitalWrite(PIN_LCD_A0_B2, LOW);
 #define _A0_1 digitalWrite(PIN_LCD_A0_B2, HIGH);
+#endif
 
 #define STATE_A_LED_BRIGHTNESS 40
 #define STATE_B_LED_BRIGHTNESS 255
@@ -315,6 +317,7 @@ extern void Timer100ms(void * parameter);
 extern void Timer1S(void * parameter);
 extern void BlinkLed(void * parameter);
 extern void getButtonState();
+extern void setLCDbacklight(uint8_t pwm);
 extern void PowerPanicESP();
 
 extern uint8_t LCDlock;

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -56,6 +56,7 @@ uint8_t lastMqttUpdate = 0;
 bool MQTTtls = false;
 bool MQTTSmartServer = false;               // Use mqtt.smartevse.nl server, can be set from the LCD menu
 bool MQTTSmartServerChanged = false;        // Flag to trigger reconnect from network_loop()
+bool WIFImodeChanged = false;               // Flag to trigger handleWIFImode() from network_loop()
 String MQTTprivatePassword;                 // mqtt.smartevse.nl pre calculated password (hash of ec_private key)
 #endif
 
@@ -1924,6 +1925,18 @@ void onWifiEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
 
 
 void handleWIFImode() {
+#if SMARTEVSE_VERSION >= 30 && SMARTEVSE_VERSION < 40
+    // Ethernet takes priority: when cable is connected, disable WiFi
+    if (EthConnected) {
+        if (WiFi.getMode() != WIFI_OFF) {
+            _LOG_A("Ethernet connected, stopping WiFi..\n");
+            WiFi.softAPdisconnect(true);
+            WiFi.disconnect(true);
+        }
+        return;
+    }
+#endif
+
     if (WIFImode == 2 && WiFi.getMode() != WIFI_AP_STA) {
         _LOG_A("Start Portal...\n");
 
@@ -2114,6 +2127,13 @@ void WiFiSetup(void) {
 void network_loop() {
     static unsigned long lastCheck_net = 0;
 
+    // Handle deferred WiFi mode changes (triggered by Ethernet events on the
+    // sys_evt task, which has too little stack for WiFi.softAP / WiFi.begin)
+    if (WIFImodeChanged) {
+        WIFImodeChanged = false;
+        handleWIFImode();
+    }
+
 #if MQTT && MQTT_ESP && SMARTEVSE_VERSION
     // Handle SmartEVSE MQTT server setting change (set by LCD menu)
     // This runs in main loop context where MQTT operations are safe
@@ -2130,7 +2150,7 @@ void network_loop() {
         time_t now;
         time(&now);                     // get seconds since Epoch
         localtime_r(&now, &timeinfo);   // convert seconds to localtime
-        if (!LocalTimeSet && WIFImode == 1) {
+        if (!LocalTimeSet && (WIFImode == 1 || EthHasIP)) {
             _LOG_A("Time not synced with NTP yet.\n");
         }
     }

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -19,6 +19,7 @@
 
 #ifndef SENSORBOX_VERSION
 #include "esp32.h"
+#include "ch390.h"
 #endif
 
 #if SMARTEVSE_VERSION >=30
@@ -180,8 +181,8 @@ void MQTTclient_t::connect(void) {
 
     client = esp_mqtt_client_init(&mqtt_cfg);
     esp_mqtt_client_register_event(client, (esp_mqtt_event_id_t) ESP_EVENT_ANY_ID, (esp_event_handler_t) mqtt_event_handler, NULL);
-    // Start now if WiFi already connected, otherwise WiFi event handler will start it
-    if (WiFi.isConnected()) {
+    // Start now if any network interface is connected (WiFi or Ethernet)
+    if (NetworkConnected()) {
         esp_mqtt_client_start(client);
     }
 }
@@ -1791,6 +1792,99 @@ void timeSyncCallback(struct timeval *tv)
     LocalTimeSet = true;
 }
 
+// Returns true if any network interface (WiFi or Ethernet) has an IP address
+bool NetworkConnected(void) {
+#if SMARTEVSE_VERSION >= 30 && SMARTEVSE_VERSION < 40
+    if (EthHasIP) return true;
+#endif
+    if (!WiFi.isConnected()) return false;
+    return WiFi.localIP() != IPAddress((uint32_t)0);
+}
+
+static bool servicesStarted = false;
+static bool mgrInitialized = false;
+
+// Ensure mongoose event manager is initialized (safe to call multiple times).
+static void ensureMgrInit(void) {
+    if (!mgrInitialized) {
+        mg_mgr_init(&mgr);
+        mgrInitialized = true;
+    }
+}
+
+// Start network services (HTTP, MQTT, mDNS, SNTP, RemoteDebug).
+// Safe to call multiple times — only starts services once.
+static void startNetworkServices(void) {
+    if (servicesStarted) return;
+    servicesStarted = true;
+
+    ensureMgrInit();
+    mg_log_set(MG_LL_NONE);
+
+    // Start HTTP listeners (bind to 0.0.0.0 — works on all interfaces)
+    if (!HttpListener80) {
+        HttpListener80 = mg_http_listen(&mgr, "http://0.0.0.0:80", fn_http_server, NULL);
+    }
+    if (!HttpListener443) {
+        HttpListener443 = mg_http_listen(&mgr, "http://0.0.0.0:443", fn_http_server, (void *)1);
+    }
+    _LOG_A("HTTP server started\n");
+
+#if MQTT
+#if MQTT_ESP == 0
+    if (!MQTTtimer) {
+        MQTTtimer = mg_timer_add(&mgr, 3000, MG_TIMER_REPEAT | MG_TIMER_RUN_NOW, timer_fn, &mgr);
+    }
+#else
+    if (MQTTHost != "" && MQTTclient.client)
+        esp_mqtt_client_start(MQTTclient.client);
+#ifdef SMARTEVSE_VERSION
+    if (MQTTSmartServer && MQTTclientSmartEVSE.client)
+        esp_mqtt_client_start(MQTTclientSmartEVSE.client);
+#endif
+#endif
+#endif //MQTT
+
+#if DBG == 1
+    Debug.begin(APhostname, 23, 1);
+    Debug.showColors(true);
+#endif
+}
+
+// Configure DNS, SNTP and mDNS when an interface gets an IP.
+// Can be called from both WiFi and Ethernet got-IP events.
+void onGotIP(const char *dns_ip) {
+    ensureMgrInit();
+
+    // Load DHCP DNS into mongoose
+    static char dns4url[] = "udp://123.123.123.123:53";
+    if (dns_ip && strlen(dns_ip) > 0) {
+        snprintf(dns4url, sizeof(dns4url), "udp://%s:53", dns_ip);
+        mgr.dns4.url = dns4url;
+    }
+
+    // Configure SNTP (safe to call again)
+    if (!esp_sntp_enabled()) {
+        esp_sntp_setservername(1, "europe.pool.ntp.org");
+        sntp_set_time_sync_notification_cb(timeSyncCallback);
+        esp_sntp_init();
+    }
+
+    if (TZinfo == "") {
+        xTaskCreate(setTimeZone, "setTimeZone", 4096, NULL, 1, NULL);
+    }
+
+    // Start mDNS
+    if (!MDNS.begin(APhostname.c_str())) {
+        _LOG_A("Error setting up MDNS responder!\n");
+    } else {
+        _LOG_A("mDNS responder started. http://%s.local\n", APhostname.c_str());
+        MDNS.addService("http", "tcp", 80);
+    }
+
+    startNetworkServices();
+}
+
 void onWifiEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
     switch (event) {
         case WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP:
@@ -1799,76 +1893,10 @@ void onWifiEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
 #else
             Serial.printf("Connected to AP: %s Local IP: %s\n", WiFi.SSID().c_str(), WiFi.localIP().toString().c_str());
 #endif            
-            //load dhcp dns ip4 address into mongoose
-            static char dns4url[]="udp://123.123.123.123:53";
-            sprintf(dns4url, "udp://%s:53", WiFi.dnsIP().toString().c_str());
-            mgr.dns4.url = dns4url;
-
-            // Init and get the time
-            // First option to get time from local ntp server blocks the second fallback option since 2021:
-            // See https://github.com/espressif/arduino-esp32/issues/4964
-            //sntp_servermode_dhcp(1);                                                    //try to get the ntp server from dhcp
-
-            // Configure time after WiFi is connected
-            esp_sntp_setservername(1, "europe.pool.ntp.org");
-            sntp_set_time_sync_notification_cb(timeSyncCallback);
-            esp_sntp_init();
-            
-            if (TZinfo == "") {
-                xTaskCreate(
-                    setTimeZone, // Function that should be called
-                    "setTimeZone",// Name of the task (for debugging)
-                    4096,           // Stack size (bytes)
-                    NULL,           // Parameter to pass
-                    1,              // Task priority - low
-                    NULL            // Task handle
-                );
-            }
-
-            // Start the mDNS responder so that the SmartEVSE can be accessed using a local hostame: http://SmartEVSE-xxxxxx.local
-            if (!MDNS.begin(APhostname.c_str())) {
-                _LOG_A("Error setting up MDNS responder!\n");
-            } else {
-                _LOG_A("mDNS responder started. http://%s.local\n",APhostname.c_str());
-                MDNS.addService("http", "tcp", 80);   // announce Web server
-            }
-
+            onGotIP(WiFi.dnsIP().toString().c_str());
             break;
         case WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_CONNECTED:
             _LOG_A("Connected or reconnected to WiFi\n");
-
-#if MQTT
-#if MQTT_ESP == 0
-            if (!MQTTtimer) {
-               MQTTtimer = mg_timer_add(&mgr, 3000, MG_TIMER_REPEAT | MG_TIMER_RUN_NOW, timer_fn, &mgr);
-            }
-#else
-            if (MQTTHost != "" && MQTTclient.client)
-                esp_mqtt_client_start(MQTTclient.client);
-#ifdef SMARTEVSE_VERSION                
-            if (MQTTSmartServer && MQTTclientSmartEVSE.client)
-                esp_mqtt_client_start(MQTTclientSmartEVSE.client);
-#endif
-#endif
-#endif //MQTT
-            mg_log_set(MG_LL_NONE);
-            //mg_log_set(MG_LL_VERBOSE);
-
-            if (!HttpListener80) {
-                HttpListener80 = mg_http_listen(&mgr, "http://0.0.0.0:80", fn_http_server, NULL);  // Setup listener
-            }
-            if (!HttpListener443) {
-                HttpListener443 = mg_http_listen(&mgr, "http://0.0.0.0:443", fn_http_server, (void *) 1);  // Setup listener
-            }
-            _LOG_A("HTTP server started\n");
-
-#if DBG == 1
-            // if we start RemoteDebug with no wifi credentials installed we get in a bootloop
-            // so we start it here
-            // Initialize the server (telnet or web socket) of RemoteDebug
-            Debug.begin(APhostname, 23, 1);
-            Debug.showColors(true); // Colors
-#endif
             break;
         case WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
             if (WIFImode == 1) {
@@ -1908,6 +1936,7 @@ void handleWIFImode() {
 #endif
         IPAddress IP = WiFi.softAPIP();
 
+        ensureMgrInit();
         if (!HttpListener80) {
             HttpListener80 = mg_http_listen(&mgr, "http://0.0.0.0:80", fn_http_server, NULL);  // Setup listener
         }
@@ -2044,7 +2073,7 @@ void WiFiSetup(void) {
         APpassword[i] = c;
     }
 
-    mg_mgr_init(&mgr);  // Initialise event manager
+    ensureMgrInit();     // Safe: no-op if Ethernet already initialised mgr
 
     WiFi.setAutoReconnect(true);                                                // Required for Arduino 3
     //WiFi.persistent(true);

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -19,7 +19,6 @@
 
 #ifndef SENSORBOX_VERSION
 #include "esp32.h"
-#include "ch390.h"
 #endif
 
 #if SMARTEVSE_VERSION >=30
@@ -1803,23 +1802,12 @@ bool NetworkConnected(void) {
 }
 
 static bool servicesStarted = false;
-static bool mgrInitialized = false;
-
-// Ensure mongoose event manager is initialized (safe to call multiple times).
-static void ensureMgrInit(void) {
-    if (!mgrInitialized) {
-        mg_mgr_init(&mgr);
-        mgrInitialized = true;
-    }
-}
 
 // Start network services (HTTP, MQTT, mDNS, SNTP, RemoteDebug).
 // Safe to call multiple times — only starts services once.
 static void startNetworkServices(void) {
     if (servicesStarted) return;
     servicesStarted = true;
-
-    ensureMgrInit();
     mg_log_set(MG_LL_NONE);
 
     // Start HTTP listeners (bind to 0.0.0.0 — works on all interfaces)
@@ -1855,8 +1843,6 @@ static void startNetworkServices(void) {
 // Configure DNS, SNTP and mDNS when an interface gets an IP.
 // Can be called from both WiFi and Ethernet got-IP events.
 void onGotIP(const char *dns_ip) {
-    ensureMgrInit();
-
     // Load DHCP DNS into mongoose
     static char dns4url[] = "udp://123.123.123.123:53";
     if (dns_ip && strlen(dns_ip) > 0) {
@@ -1949,7 +1935,6 @@ void handleWIFImode() {
 #endif
         IPAddress IP = WiFi.softAPIP();
 
-        ensureMgrInit();
         if (!HttpListener80) {
             HttpListener80 = mg_http_listen(&mgr, "http://0.0.0.0:80", fn_http_server, NULL);  // Setup listener
         }
@@ -2086,7 +2071,7 @@ void WiFiSetup(void) {
         APpassword[i] = c;
     }
 
-    ensureMgrInit();     // Safe: no-op if Ethernet already initialised mgr
+    mg_mgr_init(&mgr);
 
     WiFi.setAutoReconnect(true);                                                // Required for Arduino 3
     //WiFi.persistent(true);

--- a/SmartEVSE-3/src/network_common.h
+++ b/SmartEVSE-3/src/network_common.h
@@ -154,6 +154,8 @@ extern int downloadProgress;
 extern void WiFiSetup(void);
 extern void handleWIFImode(void);
 extern bool getLatestVersion(String owner_repo, String asset_name, char *version);
+extern bool NetworkConnected(void);                                             // true if WiFi or Ethernet has IP
+extern void onGotIP(const char *dns_ip);                                        // shared IP-acquired handler
 #ifndef SENSORBOX_VERSION
 extern std::pair<int8_t, std::array<std::int16_t, 3>> getMainsFromHomeWizardP1();
 extern String homeWizardHost;

--- a/SmartEVSE-3/src/network_common.h
+++ b/SmartEVSE-3/src/network_common.h
@@ -59,6 +59,7 @@ extern uint8_t lastMqttUpdate;
 extern bool MQTTtls;
 extern bool MQTTSmartServer;
 extern bool MQTTSmartServerChanged;        // Flag to trigger reconnect from network_loop()
+extern bool WIFImodeChanged;               // Flag to trigger handleWIFImode() from network_loop()
 extern String MQTTprivatePassword;   
 
 class MQTTclient_t {

--- a/SmartEVSE-3/src/network_common.h
+++ b/SmartEVSE-3/src/network_common.h
@@ -27,6 +27,7 @@
 
 #include "main.h" //so SENSORBOX_VERSION is read in Sensorbox
 #include "mongoose.h"
+#include "ch390.h"
 #include <ArduinoJson.h>
 
 #ifndef MQTT


### PR DESCRIPTION
Re-uses the LCD's SPI lines for:

- LCD (obviously)
- CH390D Ethernet chip (10BASE-T and 100BASE-TX and Auto-Negotiation).
- CH32V002. This chip reads the three buttons, set's the LCD brightness, and controlls the LCD's A0 and RST lines.

Software probes for the ch390 chip, and if it finds it, reconfigures the I/O lines to use this add-on.

The board itself just fits in the enclosure without interfering with other components like the capacitor, power supply or connectors.

![EtherLCD_proto](https://github.com/user-attachments/assets/080a0363-18bb-40bc-b9c8-eea26194e28c)
