### PR TITLE
OCPP: public charging station LED colour scheme when OCPP is enabled.

### DIFF
--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -1658,6 +1658,7 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
         doc["settings"]["lcdlock"] = LCDlock;
         doc["settings"]["lock"] = Lock;
         doc["settings"]["cablelock"] = CableLock;
+        doc["settings"]["ledmode"] = LedMode;
 #if MODEM
             doc["settings"]["required_evccid"] = RequiredEVCCID;
 #if SMARTEVSE_VERSION < 40

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -155,6 +155,7 @@ struct SettingsCache {
     uint8_t AutoUpdate, LCDlock, CableLock;
     uint16_t LCDPin;
     bool MQTTSmartServer;
+    uint8_t LedMode;
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION)
     uint8_t OcppMode;
 #endif
@@ -1252,6 +1253,7 @@ void read_settings() {
         strncpy(RequiredEVCCID, preferences.getString("RequiredEVCCID", "").c_str(), sizeof(RequiredEVCCID));
 #endif
         maxTemp = preferences.getUShort("maxTemp", MAX_TEMPERATURE);
+        LedMode = preferences.getUChar("LedMode", 0);
 
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
         OcppMode = preferences.getUChar("OcppMode", OCPP_MODE);
@@ -1309,6 +1311,7 @@ void read_settings() {
         settingsCache.CableLock = CableLock;
         settingsCache.LCDPin = LCDPin;
         settingsCache.MQTTSmartServer = MQTTSmartServer;
+        settingsCache.LedMode = LedMode;
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION)
         settingsCache.OcppMode = OcppMode;
 #endif
@@ -1383,6 +1386,7 @@ void write_settings(void) {
     PREFS_PUT_UCHAR_IF_CHANGED("CableLock", CableLock, CableLock);
     PREFS_PUT_USHORT_IF_CHANGED("LCDPin", LCDPin, LCDPin);
     PREFS_PUT_BOOL_IF_CHANGED("MQTTSmartServer", MQTTSmartServer, MQTTSmartServer);
+    PREFS_PUT_UCHAR_IF_CHANGED("LedMode", LedMode, LedMode);
 
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
     PREFS_PUT_UCHAR_IF_CHANGED("OcppMode", OcppMode, OcppMode);

--- a/SmartEVSE-3/src/esp32.h
+++ b/SmartEVSE-3/src/esp32.h
@@ -134,6 +134,7 @@ extern uint16_t SolarStopTimer;
 extern uint16_t MaxSumMainsTimer;
 extern uint8_t RFIDstatus;
 extern uint8_t OcppMode;
+extern uint8_t LedMode;
 extern bool LocalTimeSet;
 extern uint32_t serialnr;
 extern String PairingPin;
@@ -200,6 +201,7 @@ const struct {
     {"LCD PIN", "Pin code to operate LCD from web interface",         0, 9999, 0},
     {"APP PIN", "Generate Pairing PIN for SmartEVSE App",             0, 1, PAIRING_PIN},
     {"APP SERVR","Cloud connection for SmartEVSE App features",       0, 1, APPSERVER},
+    {"LED MODE","LED color scheme: Standard or Public",               0, 1, 0},
     {"", "Hold 2 sec to stop charging", 0, 0, 0},
     {"", "Hold 2 sec to start charging", 0, 0, 0},
 

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -1140,6 +1140,9 @@ const char * getMenuItemOption(uint8_t nav) {
         case MENU_WIFI:
         case MENU_SB2_WIFI:
             return StrWiFi[value];
+        case MENU_LEDMODE:
+            if (value) return "Public";
+            else return "Standard";
         case MENU_EXIT:
             return StrExitMenu;
         default:
@@ -1215,6 +1218,7 @@ uint8_t getMenuItems (void) {
     MenuItems[m++] = MENU_SWITCH;                                               // External Switch on SW (0:Disable / 1:Access / 2:Smart-Solar)
     MenuItems[m++] = MENU_RCMON;                                                // Residual Current Monitor on RCM (0:Disable / 1:Enable)
     MenuItems[m++] = MENU_RFIDREADER;                                           // RFID Reader connected to SW (0:Disable / 1:Enable / 2:Learn / 3:Delete / 4:Delate All)
+    MenuItems[m++] = MENU_LEDMODE;                                              // LED mode (0:Standard / 1:Public charging station colors)
     MenuItems[m++] = MENU_WIFI;                                                 // Wifi Disabled / Enabled / Portal
     if (getItemValue(MENU_WIFI)  == 1) {                                        // only show AutoUpdate menu if Wifi enabled
         MenuItems[m++] = MENU_AUTOUPDATE;                                       // Firmware automatic update Disabled / Enabled

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -1216,9 +1216,9 @@ uint8_t getMenuItems (void) {
     if (Mode != MODE_NORMAL)
         MenuItems[m++] = MENU_C2;
     MenuItems[m++] = MENU_SWITCH;                                               // External Switch on SW (0:Disable / 1:Access / 2:Smart-Solar)
+    MenuItems[m++] = MENU_LEDMODE;                                              // LED mode (0:Standard / 1:Public charging station colors)
     MenuItems[m++] = MENU_RCMON;                                                // Residual Current Monitor on RCM (0:Disable / 1:Enable)
     MenuItems[m++] = MENU_RFIDREADER;                                           // RFID Reader connected to SW (0:Disable / 1:Enable / 2:Learn / 3:Delete / 4:Delate All)
-    MenuItems[m++] = MENU_LEDMODE;                                              // LED mode (0:Standard / 1:Public charging station colors)
     MenuItems[m++] = MENU_WIFI;                                                 // Wifi Disabled / Enabled / Portal
     if (getItemValue(MENU_WIFI)  == 1) {                                        // only show AutoUpdate menu if Wifi enabled
         MenuItems[m++] = MENU_AUTOUPDATE;                                       // Firmware automatic update Disabled / Enabled

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -257,6 +257,8 @@ uint8_t ColorSmart[3] = {0, 255, 0};    // Green
 uint8_t ColorSolar[3] = {255, 170, 0};    // Orange
 uint8_t ColorCustom[3] = {0, 0, 255};    // Blue
 
+uint8_t LedMode = 0;                                                            // LED color scheme. 0:Standard / 1:Public
+
 //#define FW_UPDATE_DELAY 30        //DINGO TODO                                            // time between detection of new version and actual update in seconds
 #define FW_UPDATE_DELAY 3600                                                    // time between detection of new version and actual update in seconds
 uint16_t firmwareUpdateTimer = 0;                                               // timer for firmware updates in seconds, max 0xffff = approx 18 hours
@@ -2721,7 +2723,7 @@ static unsigned int LedPwm = 0;                                                /
         GreenPwm = ColorCustom[1];
         BluePwm = ColorCustom[2];
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION)
-    } else if (!OcppMode && (AccessStatus == OFF || State == STATE_MODEM_DENIED)) {
+    } else if (!LedMode && (AccessStatus == OFF || State == STATE_MODEM_DENIED)) {
 #else
     } else if (AccessStatus == OFF || State == STATE_MODEM_DENIED) {
 #endif
@@ -2752,7 +2754,7 @@ static unsigned int LedPwm = 0;                                                /
             }    
 
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
-    } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0)) {
+    } else if (LedMode && (RFIDReader == 6 || RFIDReader == 0)) {
         // OCPP LED color scheme (public charging)
         unsigned long now = millis();
         if (now - OcppLastRfidUpdate < 200) {
@@ -3450,6 +3452,7 @@ uint8_t setItemValue(uint8_t nav, uint16_t val) {
         SETITEM(MENU_EMCUSTOM_EDIVISOR, EMConfig[EM_CUSTOM].EDivisor)
         SETITEM(MENU_RFIDREADER, RFIDReader)
         SETITEM(MENU_AUTOUPDATE, AutoUpdate)
+        SETITEM(MENU_LEDMODE, LedMode)
         SETITEM(STATUS_SOLAR_TIMER, SolarStopTimer)
         SETITEM(STATUS_CONFIG_CHANGED, ConfigChanged)
         case MENU_C2:
@@ -3632,7 +3635,9 @@ uint16_t getItemValue(uint8_t nav) {
         case MENU_RCMON:
             return RCmon;
         case MENU_APPSERVER:
-            return MQTTSmartServer;  
+            return MQTTSmartServer;
+        case MENU_LEDMODE:
+            return LedMode;
         case STATUS_SERIAL:
             return serialnr;
 #endif

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -2754,8 +2754,8 @@ static unsigned int LedPwm = 0;                                                /
             }    
 
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
-    } else if (LedMode && (RFIDReader == 6 || RFIDReader == 0)) {
-        // OCPP LED color scheme (public charging)
+    } else if (LedMode) {
+        // Public LED color scheme
         unsigned long now = millis();
         if (now - OcppLastRfidUpdate < 200) {
             RedPwm = 128;                                                   // Grey - RFID update

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -2690,7 +2690,13 @@ void ModbusRequestLoop() {
 #if !defined(SMARTEVSE_VERSION) || SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40   //CH32 and v3 ESP32
 // Blink the RGB LED.
 //
-// NOTE: need to add multiple colour schemes 
+// When OCPP mode is active, uses public charging color scheme:
+//  Green (dim)    = Available (State A)
+//  Blue (static)  = EV connected (State B)
+//  Blue (fading)  = Charging (State C)
+//  Yellow (blink) = Waiting / Reserved
+//  Red (flash)    = Error / Fault / Unavailable
+// Otherwise uses per-Mode colors (Normal=green, Smart=green, Solar=orange)
 //
 // Task is called every 10ms
 void BlinkLed_singlerun(void) {
@@ -2714,7 +2720,11 @@ static unsigned int LedPwm = 0;                                                /
         RedPwm = ColorCustom[0];
         GreenPwm = ColorCustom[1];
         BluePwm = ColorCustom[2];
+#if ENABLE_OCPP && defined(SMARTEVSE_VERSION)
+    } else if (!OcppMode && (AccessStatus == OFF || State == STATE_MODEM_DENIED)) {
+#else
     } else if (AccessStatus == OFF || State == STATE_MODEM_DENIED) {
+#endif
         RedPwm = ColorOff[0];
         GreenPwm = ColorOff[1];
         BluePwm = ColorOff[2];
@@ -2742,40 +2752,62 @@ static unsigned int LedPwm = 0;                                                /
             }    
 
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
-    } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
-                millis() - OcppLastRfidUpdate < 200) {
-        RedPwm = 128;
-        GreenPwm = 128;
-        BluePwm = 128;
-    } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
-                millis() - OcppLastTxNotification < 1000 && OcppTrackTxNotification == MicroOcpp::TxNotification::Authorized) {
-        RedPwm = 0;
-        GreenPwm = 255;
-        BluePwm = 0;
-    } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
-                millis() - OcppLastTxNotification < 2000 && (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationRejected ||
-                                                             OcppTrackTxNotification == MicroOcpp::TxNotification::DeAuthorized ||
-                                                             OcppTrackTxNotification == MicroOcpp::TxNotification::ReservationConflict)) {
-        RedPwm = 255;
-        GreenPwm = 0;
-        BluePwm = 0;
-    } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
-                millis() - OcppLastTxNotification < 300 && (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationTimeout ||
-                                                            OcppTrackTxNotification == MicroOcpp::TxNotification::ConnectionTimeout)) {
-        RedPwm = 255;
-        GreenPwm = 0;
-        BluePwm = 0;
-    } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
-                getChargePointStatus() == ChargePointStatus_Reserved) {
-        RedPwm = 196;
-        GreenPwm = 64;
-        BluePwm = 0;
-    } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
-                (getChargePointStatus() == ChargePointStatus_Unavailable ||
-                 getChargePointStatus() == ChargePointStatus_Faulted)) {
-        RedPwm = 255;
-        GreenPwm = 0;
-        BluePwm = 0;
+    } else if (OcppMode && (RFIDReader == 6 || RFIDReader == 0)) {
+        // OCPP LED color scheme (public charging)
+        unsigned long now = millis();
+        if (now - OcppLastRfidUpdate < 200) {
+            RedPwm = 128;                                                   // Grey - RFID update
+            GreenPwm = 128;
+            BluePwm = 128;
+        } else if (now - OcppLastTxNotification < 1000 && OcppTrackTxNotification == MicroOcpp::TxNotification::Authorized) {
+            RedPwm = 0;                                                     // Green flash - Authorized
+            GreenPwm = 255;
+            BluePwm = 0;
+        } else if (now - OcppLastTxNotification < 2000 && (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationRejected ||
+                                                            OcppTrackTxNotification == MicroOcpp::TxNotification::DeAuthorized ||
+                                                            OcppTrackTxNotification == MicroOcpp::TxNotification::ReservationConflict)) {
+            RedPwm = 255;                                                   // Red flash - Rejected
+            GreenPwm = 0;
+            BluePwm = 0;
+        } else if (now - OcppLastTxNotification < 300 && (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationTimeout ||
+                                                           OcppTrackTxNotification == MicroOcpp::TxNotification::ConnectionTimeout)) {
+            RedPwm = 255;                                                   // Red flash - Timeout
+            GreenPwm = 0;
+            BluePwm = 0;
+        } else if (getChargePointStatus() == ChargePointStatus_Reserved) {
+            RedPwm = 255;                                                   // Orange - Reserved
+            GreenPwm = 128;
+            BluePwm = 0;
+        } else if (getChargePointStatus() == ChargePointStatus_Unavailable ||
+                   getChargePointStatus() == ChargePointStatus_Faulted) {
+            RedPwm = 255;                                                   // Red - Unavailable/Faulted
+            GreenPwm = 0;
+            BluePwm = 0;
+        } else if (ErrorFlags || ChargeDelay) {                             // Waiting for power / delayed
+            LedCount += 2;                                                  // Slow blinking orange
+            if (LedCount > 230) LedPwm = WAITING_LED_BRIGHTNESS;
+            else LedPwm = 0;
+            RedPwm = LedPwm;
+            GreenPwm = LedPwm / 2;
+            BluePwm = 0;
+        } else if (State == STATE_A) {
+            LedPwm = STATE_A_LED_BRIGHTNESS;                                // Green (dimmed) - Available
+            RedPwm = 0;
+            GreenPwm = LedPwm;
+            BluePwm = 0;
+        } else if (State == STATE_B || State == STATE_B1 || State == STATE_MODEM_REQUEST || State == STATE_MODEM_WAIT) {
+            LedPwm = STATE_B_LED_BRIGHTNESS;                                // Blue (static) - EV connected
+            LedCount = 128;
+            RedPwm = 0;
+            GreenPwm = 0;
+            BluePwm = LedPwm;
+        } else if (State == STATE_C) {
+            LedCount += 2;                                                  // Blue fading - Charging
+            LedPwm = ease8InOutQuad(triwave8(LedCount));
+            RedPwm = 0;
+            GreenPwm = 0;
+            BluePwm = LedPwm;
+        }
 #endif //ENABLE_OCPP
     } else {                                                                // State A, B or C
 

--- a/SmartEVSE-3/src/main.h
+++ b/SmartEVSE-3/src/main.h
@@ -289,9 +289,10 @@ void setPilot(bool On);
 #define MENU_LCDPIN 40
 #define MENU_PAIRING 41
 #define MENU_APPSERVER 42
-#define MENU_OFF 43                                                             // so access bit is reset and charging stops when pressing < button 2 seconds
-#define MENU_ON 44                                                              // so access bit is set and charging starts when pressing > button 2 seconds
-#define MENU_EXIT 45
+#define MENU_LEDMODE 43
+#define MENU_OFF 44                                                             // so access bit is reset and charging stops when pressing < button 2 seconds
+#define MENU_ON 45                                                              // so access bit is set and charging starts when pressing > button 2 seconds
+#define MENU_EXIT 46
 
 #define MENU_STATE 50
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,6 +209,12 @@ Only appears when [CAPACITY](#capacity) is configured. Timer in minutes. If CAPA
 Pin code so that you can use the buttons on the LCD menu on the web-interface.
 Left button increases the digit by one, Right button goes to next digit, Middle button ends entry.
 
+## LED MODE
+Select the LED color scheme for the SmartEVSE.
+
+- **Standard**: The default green/red color scheme. Green = Normal or Smart mode, Yellow = Solar mode. Red indicates errors or waiting. Custom LED colors can be set via MQTT.
+- **Public**: The color scheme used for public charging stations. Green = available, Blue (static) = EV connected / charging finished, Blue (fading) = charging, Yellow = reserved / waiting, Red = error / fault. Note that the blue led output is only available on the 6 pin Button connector.
+
 ## CONTACT2
 Use a second contactor (C2) to switch phases L2 and L3. 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,6 +110,12 @@ Set the Function of an External Switch (Pin SW or Connector P2).
 - **Custom B**: A momentary push button can be used for external integrations.
 - **Custom S**: A toggle switch can be used for external integrations.
 
+## LED MODE
+Select the LED color scheme for the SmartEVSE.
+
+- **Standard**: The default green/red color scheme. Green = Normal or Smart mode, Yellow = Solar mode. Red indicates errors or waiting. Custom LED colors can be set via MQTT.
+- **Public**: The color scheme used for public charging stations. Green = available, Blue (static) = EV connected / charging finished, Blue (fading) = charging, Yellow = reserved / waiting, Red = error / fault. Note that the blue LED output is only available on the 6 pin Button connector.
+
 ## RCMON
 Residual Current Monitor (RCM14-03) plugged into connector P1.
 
@@ -208,12 +214,6 @@ Only appears when [CAPACITY](#capacity) is configured. Timer in minutes. If CAPA
 ## LCD PIN
 Pin code so that you can use the buttons on the LCD menu on the web-interface.
 Left button increases the digit by one, Right button goes to next digit, Middle button ends entry.
-
-## LED MODE
-Select the LED color scheme for the SmartEVSE.
-
-- **Standard**: The default green/red color scheme. Green = Normal or Smart mode, Yellow = Solar mode. Red indicates errors or waiting. Custom LED colors can be set via MQTT.
-- **Public**: The color scheme used for public charging stations. Green = available, Blue (static) = EV connected / charging finished, Blue (fading) = charging, Yellow = reserved / waiting, Red = error / fault. Note that the blue led output is only available on the 6 pin Button connector.
 
 ## CONTACT2
 Use a second contactor (C2) to switch phases L2 and L3. 


### PR DESCRIPTION
When OCPP is enabled this will change the LED colour to

Green (dim)    = Available (State A)
Blue (static)  = EV connected (State B)
Blue (fading)  = Charging (State C)
Yellow (blink) = Waiting / Reserved
Red (flash)    = Error / Fault / Unavailable

Just like most public charging stations.

Unsure if this should be configurable somehow.