### PR TITLE
Lcd via websocket - bugfix connection error

### DIFF
--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -693,7 +693,11 @@
                                         <div class="lcd-status">
                                           <form class="lcd-password" id="lcd-password-form">
                                             <input type="password" id="lcd-password" class="form-control"
-                                                                                     placeholder="Enter PIN">
+                                                                                     placeholder="Enter PIN"
+                                                                                     inputmode="numeric"
+                                                                                     autocomplete="off"
+                                                                                     maxlength="4"
+                                                                                     pattern="[0-9]{4}">
                                             <button type="submit" id="lcd-password-submit">Unlock</button>
                                           </form>
                                           <div class="lcd-lock-status" id="lcd-lock-status">
@@ -839,6 +843,14 @@
             }
         }
 
+        function normalizePin(pin) {
+            return typeof pin === 'string' ? pin.trim() : '';
+        }
+
+        function isValidPin(pin) {
+            return /^\d{4}$/.test(pin);
+        }
+
         function updateLockUi(isUnlocked) {
             if (isUnlocked) {
                 LOCK_STATUS.textContent = 'Unlocked';
@@ -980,9 +992,21 @@
         }
 
         function verifyPassword(options = {}) {
-            const enteredPassword = options.password ?? PASSWORD_FIELD.value;
+            const enteredPassword = normalizePin(options.password ?? PASSWORD_FIELD.value);
             const showErrorAlert = options.showErrorAlert ?? true;
             const rememberPin = options.rememberPin ?? true;
+            if (!isValidPin(enteredPassword)) {
+                passwordVerified = false;
+                updateLockUi(false);
+                if (rememberPin) {
+                    clearStoredPin();
+                }
+                if (showErrorAlert) {
+                    alert("Enter the 4-digit PIN.");
+                }
+                return;
+            }
+
             $.post('/lcd-verify-password', { password: enteredPassword })
             .done(function(data) {
                 if (data.success) {
@@ -999,6 +1023,13 @@
                     if (showErrorAlert) {
                         alert("Incorrect PIN. Please try again.");
                     }
+                }
+            })
+            .fail(function() {
+                passwordVerified = false;
+                updateLockUi(false);
+                if (showErrorAlert) {
+                    alert("PIN verification failed. Please try again.");
                 }
             });
         }
@@ -1039,10 +1070,11 @@
         });
 
         const storedPin = getStoredPin();
-        if (storedPin) {
+        if (isValidPin(storedPin)) {
             PASSWORD_FIELD.value = storedPin;
             verifyPassword({ password: storedPin, showErrorAlert: false, rememberPin: false });
         } else {
+            clearStoredPin();
             updateLockUi(false);
         }
 

--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -891,7 +891,6 @@
             socket.onopen = () => {
                 clearConnectTimeout();
                 resetWsRetryState();
-                setActivateText('Connected', 'success');
                 hideActivateOverlayAfterDelay(WS_CONNECTED_STATUS_MS);
             };
 

--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -48,7 +48,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 
   <script>
-      let endpoint = document.location + 'settings';
+      let endpoint = '/settings';
       // let endpoint = 'http://10.0.0.36/settings';
       let initiated=false;
       let mqttEditMode = false;

--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -678,6 +678,7 @@
                                       <div class="lcd" id="lcd">
                                           <img class="lcd-device" src="SmartEVSE.webp" width="401" height="600" alt=""/>
                                           <img class="lcd-screen" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAmMBgX1lyz4AAAAASUVORK5CYII=" width="256" height="128" alt=""/>
+                                          <div class="lcd-activate" data-state="info">Starting websocket...</div>
                                           <div class="lcd-display-buttons">
                                               <button type="button" data-name="left">Left</button>
                                               <button type="button" data-name="middle">Middle</button>
@@ -688,14 +689,20 @@
                                               <button type="button" data-name="middle">Middle</button>
                                               <button type="button" data-name="right">Right</button>
                                           </div>
+
+                                        <div class="lcd-status">
                                           <form class="lcd-password" id="lcd-password-form">
-                                              <input type="password" id="lcd-password" class="form-control" placeholder="Enter PIN" style="width: 5em;">
-                                              <button type="submit" id="lcd-password-submit">Unlock</button>
-                                              <span id="lcd-lock-status" style="color: #e74a3b; font-weight: 700; white-space: nowrap;" title="Button lock status">Locked - Enter PIN</span>
+                                            <input type="password" id="lcd-password" class="form-control"
+                                                                                     placeholder="Enter PIN">
+                                            <button type="submit" id="lcd-password-submit">Unlock</button>
                                           </form>
-                                          <div id="lcd-lock-hint">
-                                              LCD buttons are locked. Enter your PIN to unlock them.
+                                          <div class="lcd-lock-status" id="lcd-lock-status">
+                                            Locked - Enter PIN
                                           </div>
+                                          <div id="lcd-lock-hint">
+                                            LCD buttons are locked. Enter your PIN to unlock them.
+                                          </div>
+                                        </div>
                                       </div>
 <script>
     (() => {
@@ -709,28 +716,72 @@
         const SESSION_STORAGE_PIN_KEY = 'lcdPinCode';
         const LOCKED_PRESS_ALERT_THRESHOLD = 3;
         const MIN_BUTTON_PRESS_MS = 300;
-        const WS_RECONNECT_BASE_MS = 1000;
-        const WS_RECONNECT_MAX_MS = 10000;
-        const WS_RECONNECT_JITTER_MS = 400;
-        const WS_INITIAL_RETRY_MS = 750;
-        const WS_INITIAL_RETRY_JITTER_MS = 250;
-        const WS_CONNECT_TIMEOUT_MS = 5000;
+        const WS_MAX_CONNECT_ATTEMPTS = 3;
+        const WS_CONNECTED_STATUS_MS = 2000;
+        const WS_RETRY_DELAY_MS = 2000;
+        const WS_CONNECT_TIMEOUT_MS = 8000;
         const WS_URL = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws/lcd`;
         let passwordVerified = false;
         let blockedButtonPressCount = 0;
         let lcdSocket = null;
         let reconnectTimer = null;
         let connectTimeoutTimer = null;
-        let reconnectAttempts = 0;
-        let hasConnectedOnce = false;
-        let wsPausedByVisibility = false;
+        let activateOverlayHideTimer = null;
         let activeFrameUrl = null;
+        let wsAttemptCount = 0;
+        let wsStopped = false;
+        let wsErrorText = '';
         const activePointers = new Map();
 
-        function setActivateText(text) {
+        function setActivateText(text, state = 'info') {
+            clearActivateOverlayHideTimer();
             if (LCD_ACTIVATE) {
                 LCD_ACTIVATE.textContent = text;
+                LCD_ACTIVATE.dataset.state = state;
+                LCD_ACTIVATE.classList.remove('is-hidden');
             }
+        }
+
+        function clearActivateOverlayHideTimer() {
+            if (activateOverlayHideTimer !== null) {
+                window.clearTimeout(activateOverlayHideTimer);
+                activateOverlayHideTimer = null;
+            }
+        }
+
+        function hideActivateOverlayAfterDelay(delayMs) {
+            clearActivateOverlayHideTimer();
+            activateOverlayHideTimer = window.setTimeout(() => {
+                activateOverlayHideTimer = null;
+                hideActivateOverlay();
+            }, delayMs);
+        }
+
+        function hideActivateOverlay() {
+            clearActivateOverlayHideTimer();
+            if (LCD_ACTIVATE) {
+                LCD_ACTIVATE.classList.add('is-hidden');
+            }
+        }
+
+        function setWsStatus(prefix, state = 'info') {
+            const attemptNumber = Math.min(wsAttemptCount + 1, WS_MAX_CONNECT_ATTEMPTS);
+            const details = wsErrorText ? `\n${wsErrorText}` : '';
+            setActivateText(`${prefix}\nAttempt ${attemptNumber}/${WS_MAX_CONNECT_ATTEMPTS}${details}`, state);
+        }
+
+        function resetWsRetryState() {
+            wsAttemptCount = 0;
+            wsStopped = false;
+            wsErrorText = '';
+        }
+
+        function stopReconnectWithFinalError(errorText) {
+            wsStopped = true;
+            wsErrorText = errorText;
+            clearReconnectTimer();
+            clearConnectTimeout();
+            setActivateText(`WebSocket failed after ${WS_MAX_CONNECT_ATTEMPTS} attempts.\n${errorText}`, 'error');
         }
 
         function clearConnectTimeout() {
@@ -747,55 +798,21 @@
             }
         }
 
-        function shouldKeepWsActive() {
-            return !wsPausedByVisibility;
-        }
-
-        function requestImmediateReconnect() {
-            if (!shouldKeepWsActive()) {
-                return;
-            }
-            reconnectAttempts = 0;
+        function restartLCDWebSocket() {
+            resetWsRetryState();
             clearReconnectTimer();
             connectLCDWebSocket();
         }
 
-        function disconnectLCDWebSocket() {
-            clearConnectTimeout();
-            clearReconnectTimer();
-            if (lcdSocket && (lcdSocket.readyState === WebSocket.OPEN || lcdSocket.readyState === WebSocket.CONNECTING)) {
-                lcdSocket.close();
-            }
-        }
-
         function scheduleReconnect() {
-            if (!shouldKeepWsActive()) {
+            if (wsStopped || reconnectTimer !== null) {
                 return;
             }
-            if (reconnectTimer !== null) {
-                return;
-            }
-            const backoffMs = hasConnectedOnce
-                ? Math.min(WS_RECONNECT_BASE_MS * (2 ** reconnectAttempts), WS_RECONNECT_MAX_MS)
-                : WS_INITIAL_RETRY_MS;
-            const jitterMs = hasConnectedOnce
-                ? Math.floor(Math.random() * WS_RECONNECT_JITTER_MS)
-                : Math.floor(Math.random() * WS_INITIAL_RETRY_JITTER_MS);
-            const reconnectDelayMs = backoffMs + jitterMs;
-            reconnectAttempts += 1;
-            setActivateText(`Reconnecting in ${Math.ceil(reconnectDelayMs / 1000)}s...`);
+            setWsStatus('Reconnecting in 2s...', 'warning');
             reconnectTimer = window.setTimeout(() => {
                 reconnectTimer = null;
                 connectLCDWebSocket();
-            }, reconnectDelayMs);
-        }
-
-        function activateLCD() {
-            if (!LCD_ACTIVATE) {
-                return;
-            }
-            LCD_ACTIVATE.remove();
-            LCD_ACTIVATE = null;
+            }, WS_RETRY_DELAY_MS);
         }
 
         function getStoredPin() {
@@ -835,30 +852,47 @@
         }
 
         function connectLCDWebSocket() {
-            if (!shouldKeepWsActive()) {
-                return;
-            }
             if (lcdSocket && (lcdSocket.readyState === WebSocket.OPEN || lcdSocket.readyState === WebSocket.CONNECTING)) {
                 return;
             }
 
-            setActivateText('Connecting...');
-            const socket = new WebSocket(WS_URL);
+            if (wsAttemptCount >= WS_MAX_CONNECT_ATTEMPTS) {
+                stopReconnectWithFinalError(wsErrorText || 'connection failed');
+                return;
+            }
+
+            setWsStatus('Connecting to LCD websocket...', 'info');
+
+            let socket;
+            try {
+                socket = new WebSocket(WS_URL);
+            } catch (error) {
+                wsAttemptCount += 1;
+                wsErrorText = `constructor error: ${error.message}`;
+                if (wsAttemptCount >= WS_MAX_CONNECT_ATTEMPTS) {
+                    stopReconnectWithFinalError(wsErrorText);
+                    return;
+                }
+                scheduleReconnect();
+                return;
+            }
+
             lcdSocket = socket;
             socket.binaryType = 'arraybuffer';
 
             clearConnectTimeout();
             connectTimeoutTimer = window.setTimeout(() => {
                 if (socket.readyState === WebSocket.CONNECTING) {
+                    wsErrorText = `connect timeout after ${WS_CONNECT_TIMEOUT_MS}ms`;
                     socket.close();
                 }
             }, WS_CONNECT_TIMEOUT_MS);
 
             socket.onopen = () => {
                 clearConnectTimeout();
-                reconnectAttempts = 0;
-                hasConnectedOnce = true;
-                activateLCD();
+                resetWsRetryState();
+                setActivateText('Connected', 'success');
+                hideActivateOverlayAfterDelay(WS_CONNECTED_STATUS_MS);
             };
 
             socket.onmessage = (event) => {
@@ -874,19 +908,31 @@
             };
 
             socket.onerror = () => {
+                wsErrorText = 'connection error';
                 if (socket.readyState !== WebSocket.CLOSED) {
                     socket.close();
                 }
             };
 
-            socket.onclose = () => {
+            socket.onclose = (event) => {
                 clearConnectTimeout();
                 if (lcdSocket === socket) {
                     lcdSocket = null;
                 }
-                if (shouldKeepWsActive()) {
-                    scheduleReconnect();
+                if (event.code === 1000) {
+                    return;
                 }
+                wsAttemptCount += 1;
+                if (event.code === 1006) {
+                    wsErrorText = wsErrorText || 'connection lost';
+                } else if (!wsErrorText) {
+                    wsErrorText = `close code ${event.code}`;
+                }
+                if (wsAttemptCount >= WS_MAX_CONNECT_ATTEMPTS) {
+                    stopReconnectWithFinalError(wsErrorText);
+                    return;
+                }
+                scheduleReconnect();
             };
         }
 
@@ -904,7 +950,7 @@
             }
 
             if (!lcdSocket || lcdSocket.readyState !== WebSocket.OPEN) {
-                requestImmediateReconnect();
+                restartLCDWebSocket();
                 return;
             }
 
@@ -986,24 +1032,11 @@
         });
 
         window.addEventListener('online', () => {
-            requestImmediateReconnect();
+            restartLCDWebSocket();
         });
 
         window.addEventListener('offline', () => {
-            setActivateText('Offline - waiting for network...');
-        });
-
-        document.addEventListener('visibilitychange', () => {
-            if (document.hidden) {
-                wsPausedByVisibility = true;
-                setActivateText('Paused in background');
-                disconnectLCDWebSocket();
-                return;
-            }
-
-            wsPausedByVisibility = false;
-            setActivateText('Reconnecting...');
-            requestImmediateReconnect();
+            setActivateText('Offline - waiting for network...', 'warning');
         });
 
         const storedPin = getStoredPin();
@@ -1014,12 +1047,7 @@
             updateLockUi(false);
         }
 
-        if (document.hidden) {
-            wsPausedByVisibility = true;
-            setActivateText('Paused in background');
-        } else {
-            requestImmediateReconnect();
-        }
+        restartLCDWebSocket();
     })();
 </script>
                                   </div>

--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -677,7 +677,7 @@
                                   <div class="row no-gutters align-items-center">
                                       <div class="lcd" id="lcd">
                                           <img class="lcd-device" src="SmartEVSE.webp" width="401" height="600" alt=""/>
-                                          <img class="lcd-screen" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAmMBgX1lyz4AAAAASUVORK5CYII=" width="256" height="128" alt=""/>
+                                          <img class="lcd-screen is-hidden" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAmMBgX1lyz4AAAAASUVORK5CYII=" width="256" height="128" alt="" />
                                           <div class="lcd-activate" data-state="info">Starting websocket...</div>
                                           <div class="lcd-display-buttons">
                                               <button type="button" data-name="left">Left</button>
@@ -712,7 +712,7 @@
     (() => {
         const LCD_SCREEN = document.querySelector('#lcd .lcd-screen');
         const LCD_BUTTON_CONTAINERS = document.querySelectorAll('#lcd .lcd-buttons, #lcd .lcd-display-buttons');
-        let LCD_ACTIVATE = document.querySelector('#lcd .lcd-activate');
+        const LCD_ACTIVATE = document.querySelector('#lcd .lcd-activate');
         const PASSWORD_FIELD = document.querySelector('#lcd-password');
         const PASSWORD_FORM = document.querySelector('#lcd-password-form');
         const LOCK_STATUS = document.querySelector('#lcd-lock-status');
@@ -737,6 +737,13 @@
         let wsErrorText = '';
         const activePointers = new Map();
 
+        /**
+         * Update the LCD overlay text and make sure it is visible.
+         *
+         * @param {string} text Overlay text to display.
+         * @param {'info'|'warning'|'error'} [state='info'] Visual state for the overlay.
+         * @returns {void}
+         */
         function setActivateText(text, state = 'info') {
             clearActivateOverlayHideTimer();
             if (LCD_ACTIVATE) {
@@ -746,6 +753,11 @@
             }
         }
 
+        /**
+         * Cancel any pending timer that would hide the LCD overlay.
+         *
+         * @returns {void}
+         */
         function clearActivateOverlayHideTimer() {
             if (activateOverlayHideTimer !== null) {
                 window.clearTimeout(activateOverlayHideTimer);
@@ -753,6 +765,12 @@
             }
         }
 
+        /**
+         * Hide the LCD overlay after a delay once the websocket is healthy.
+         *
+         * @param {number} delayMs Delay in milliseconds before hiding the overlay.
+         * @returns {void}
+         */
         function hideActivateOverlayAfterDelay(delayMs) {
             clearActivateOverlayHideTimer();
             activateOverlayHideTimer = window.setTimeout(() => {
@@ -761,6 +779,11 @@
             }, delayMs);
         }
 
+        /**
+         * Hide the LCD overlay immediately.
+         *
+         * @returns {void}
+         */
         function hideActivateOverlay() {
             clearActivateOverlayHideTimer();
             if (LCD_ACTIVATE) {
@@ -768,18 +791,40 @@
             }
         }
 
+        /**
+         * Show the current websocket state together with retry details.
+         *
+         * @param {string} prefix Status text to display before retry details.
+         * @param {'info'|'warning'|'error'} [state='info'] Visual state for the overlay.
+         * @returns {void}
+         */
         function setWsStatus(prefix, state = 'info') {
-            const attemptNumber = Math.min(wsAttemptCount + 1, WS_MAX_CONNECT_ATTEMPTS);
-            const details = wsErrorText ? `\n${wsErrorText}` : '';
+          const attemptNumber = Math.min(wsAttemptCount + 1, WS_MAX_CONNECT_ATTEMPTS);
+          const details = wsErrorText ? `\n${wsErrorText}` : '';
+          if (attemptNumber > 1) {
             setActivateText(`${prefix}\nAttempt ${attemptNumber}/${WS_MAX_CONNECT_ATTEMPTS}${details}`, state);
+          } else {
+            setActivateText(prefix, state);
+          }
         }
 
+        /**
+         * Reset websocket retry bookkeeping before a fresh connection cycle.
+         *
+         * @returns {void}
+         */
         function resetWsRetryState() {
             wsAttemptCount = 0;
             wsStopped = false;
             wsErrorText = '';
         }
 
+        /**
+         * Stop reconnect attempts and show the final websocket error.
+         *
+         * @param {string} errorText Final error message shown to the user.
+         * @returns {void}
+         */
         function stopReconnectWithFinalError(errorText) {
             wsStopped = true;
             wsErrorText = errorText;
@@ -802,12 +847,22 @@
             }
         }
 
+        /**
+         * Restart the LCD websocket from a clean retry state.
+         *
+         * @returns {void}
+         */
         function restartLCDWebSocket() {
             resetWsRetryState();
             clearReconnectTimer();
             connectLCDWebSocket();
         }
 
+        /**
+         * Queue the next websocket reconnect attempt if retries are still allowed.
+         *
+         * @returns {void}
+         */
         function scheduleReconnect() {
             if (wsStopped || reconnectTimer !== null) {
                 return;
@@ -843,10 +898,22 @@
             }
         }
 
+        /**
+         * Normalize a PIN value so validation always works on trimmed text.
+         *
+         * @param {unknown} pin PIN candidate from storage or user input.
+         * @returns {string} Trimmed PIN text or an empty string for invalid input types.
+         */
         function normalizePin(pin) {
             return typeof pin === 'string' ? pin.trim() : '';
         }
 
+        /**
+         * Check whether a PIN is exactly four numeric digits.
+         *
+         * @param {string} pin PIN text to validate.
+         * @returns {boolean} True when the PIN contains exactly four digits.
+         */
         function isValidPin(pin) {
             return /^\d{4}$/.test(pin);
         }
@@ -863,17 +930,22 @@
             }
         }
 
+        /**
+         * Open the LCD websocket and manage retries, errors, and UI state.
+         *
+         * @returns {void}
+         */
         function connectLCDWebSocket() {
             if (lcdSocket && (lcdSocket.readyState === WebSocket.OPEN || lcdSocket.readyState === WebSocket.CONNECTING)) {
                 return;
             }
 
             if (wsAttemptCount >= WS_MAX_CONNECT_ATTEMPTS) {
+              wsErrorText = `connect timeout after ${WS_CONNECT_TIMEOUT_MS}ms`
                 stopReconnectWithFinalError(wsErrorText || 'connection failed');
                 return;
             }
-
-            setWsStatus('Connecting to LCD websocket...', 'info');
+            setWsStatus('Connecting to LCD...', 'info');
 
             let socket;
             try {
@@ -916,6 +988,7 @@
                 }
                 activeFrameUrl = frameUrl;
                 LCD_SCREEN.src = frameUrl;
+                LCD_SCREEN.classList.remove('is-hidden');
             };
 
             socket.onerror = () => {
@@ -947,6 +1020,13 @@
             };
         }
 
+        /**
+         * Send a button press or release event to the LCD websocket.
+         *
+         * @param {string} btnName Logical LCD button name.
+         * @param {boolean} stateDown True when the button is pressed, false when released.
+         * @returns {void}
+         */
         function sendButtonState(btnName, stateDown) {
             if (!passwordVerified) {
                 blockedButtonPressCount += 1;
@@ -991,6 +1071,12 @@
             }
         }
 
+        /**
+         * Verify the configured LCD PIN and optionally persist it for this session.
+         *
+         * @param {{password?: string, showErrorAlert?: boolean, rememberPin?: boolean}} [options={}] Verification overrides.
+         * @returns {void}
+         */
         function verifyPassword(options = {}) {
             const enteredPassword = normalizePin(options.password ?? PASSWORD_FIELD.value);
             const showErrorAlert = options.showErrorAlert ?? true;

--- a/SmartEVSE-3/data/styling.css
+++ b/SmartEVSE-3/data/styling.css
@@ -119,7 +119,6 @@
 
 #lcd .lcd-activate[data-state="warning"] {
     color: #8a5a00;
-    color: var(--warning);
     background-color: rgba(253, 243, 216, .92);
 }
 

--- a/SmartEVSE-3/data/styling.css
+++ b/SmartEVSE-3/data/styling.css
@@ -103,15 +103,14 @@
     left: 60px;
     z-index: 1;
     padding: 1rem;
-    background-color: rgba(245, 245, 245, .88);
+    background-color: rgba(255, 255, 255, .80);
     color: var(--gray-dark);
-    font-size: 1rem;
-    font-weight: 700;
+    font-size: 1.33rem;
     line-height: 1.35;
     text-align: center;
     white-space: pre-wrap;
-    user-select: text;
     pointer-events: none;
+    text-wrap: balance;
 }
 
 #lcd .lcd-activate.is-hidden {
@@ -120,6 +119,7 @@
 
 #lcd .lcd-activate[data-state="warning"] {
     color: #8a5a00;
+    color: var(--warning);
     background-color: rgba(253, 243, 216, .92);
 }
 

--- a/SmartEVSE-3/data/styling.css
+++ b/SmartEVSE-3/data/styling.css
@@ -23,10 +23,6 @@
     image-rendering: pixelated;
     padding: 20px 6px;
     filter: hue-rotate(250deg) brightness(95%);
-    background-image: url('data:image/svg+xml,<svg width="36" height="36" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><style>.spinner_aj0A{transform-origin:center;animation:spinner_KYSC .75s infinite linear}@keyframes spinner_KYSC{100%{transform:rotate(360deg)}}</style><path d="M12,4a8,8,0,0,1,7.89,6.7A1.53,1.53,0,0,0,21.38,12h0a1.5,1.5,0,0,0,1.48-1.75,11,11,0,0,0-21.72,0A1.5,1.5,0,0,0,2.62,12h0a1.53,1.53,0,0,0,1.49-1.3A8,8,0,0,1,12,4Z" class="spinner_aj0A"/></svg>');
-    background-size: 25%;
-    background-position: center;
-    background-repeat: no-repeat;
     background-color: #FDFDFD;
 }
 
@@ -70,49 +66,71 @@
     box-shadow: none;
 }
 
+#lcd .lcd-status {
+    max-width: 386px;
+    padding: 1em 1em 0 1em;
+}
+
 #lcd .lcd-password {
     display: flex;
     align-items: center;
     gap: 10px;
-    width: 350px;
-    margin: 10px 0 0 20px;
+}
+
+#lcd .lcd-lock-status {
+    color: var(--danger);
+    font-weight: bold;
+    margin-top: .5em;
 }
 
 #lcd #lcd-password {
-    width: 130px;
-}
-
-#lcd #lcd-lock-status {
-    margin-left: auto;
-    text-align: right;
+    width: 7em;
 }
 
 #lcd #lcd-lock-hint {
-    width: 350px;
-    margin: 8px 0 0 20px;
-    color: #6e707e;
-    font-size: .95rem;
-    line-height: 1.3;
+    margin-top: .5em;
+    color: var(--gray-dark);
 }
 
 #lcd .lcd-activate {
     position: absolute;
-    display: grid;
-    place-content: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 270px;
     height: 168px;
     top: 156px;
     left: 60px;
-    background-color: rgba(245, 245, 245, .7);
-    font-size: 2rem;
-    opacity: 0;
-    user-select: none;
-    cursor: pointer;
-    transition: opacity 0.3s ease;
+    z-index: 1;
+    padding: 1rem;
+    background-color: rgba(245, 245, 245, .88);
+    color: var(--gray-dark);
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.35;
+    text-align: center;
+    white-space: pre-wrap;
+    user-select: text;
+    pointer-events: none;
 }
 
-#lcd .lcd-activate:hover {
-    opacity: 1;
+#lcd .lcd-activate.is-hidden {
+    display: none;
+}
+
+#lcd .lcd-activate[data-state="warning"] {
+    color: #8a5a00;
+    background-color: rgba(253, 243, 216, .92);
+}
+
+#lcd .lcd-activate[data-state="success"] {
+    color: #0f6848;
+    background-color: rgba(210, 244, 232, .94);
+}
+
+#lcd .lcd-activate[data-state="error"] {
+    color: var(--danger);
+    background-color: rgba(250, 219, 216, .94);
 }
 
 /* Green selected button. */

--- a/SmartEVSE-3/data/styling.css
+++ b/SmartEVSE-3/data/styling.css
@@ -123,11 +123,6 @@
     background-color: rgba(253, 243, 216, .92);
 }
 
-#lcd .lcd-activate[data-state="success"] {
-    color: #0f6848;
-    background-color: rgba(210, 244, 232, .94);
-}
-
 #lcd .lcd-activate[data-state="error"] {
     color: var(--danger);
     background-color: rgba(250, 219, 216, .94);

--- a/SmartEVSE-3/packfs.py
+++ b/SmartEVSE-3/packfs.py
@@ -12,10 +12,13 @@ import os, sys, gzip, shutil, re
 # - Smaller assets reduce flash/storage usage and transfer overhead.
 #
 # Safety:
-# - Minification is whitespace/comment-focused for HTML/CSS structure.
+# - Minification is conservative and avoids transformations that can change
+#   runtime behavior.
 # - Runtime functionality is unchanged (same DOM/script logic and CSS rules).
 # - Script/style/pre/textarea blocks are protected for HTML minification so
 #   their content is not altered.
+# - Inline JavaScript is left untouched except for `/* ... */` block comments
+#   inside script blocks.
 
 def minify_css(content):
     # Compact CSS by removing comments and unnecessary whitespace.
@@ -30,12 +33,17 @@ def minify_html(content):
     # Protect blocks where whitespace/content must remain untouched.
     blocks = []
     def protect(match):
-        blocks.append(match.group(0))
+        block = match.group(0)
+        if match.group(1).lower() == "script":
+            # Remove block comments from inline JavaScript only.
+            block = re.sub(r"/\*[\s\S]*?\*/", "", block)
+        blocks.append(block)
         return "___HTML_BLOCK_" + str(len(blocks) - 1) + "___"
 
     content = re.sub(r"<(script|style|pre|textarea)\b[\s\S]*?</\1>", protect, content, flags=re.IGNORECASE)
+    # Remove HTML comments outside protected blocks.
     content = re.sub(r"<!--[\s\S]*?-->", "", content)
-    content = re.sub(r"\s{2,}", " ", content)
+    # Remove whitespace that exists only between adjacent tags.
     content = re.sub(r">\s+<", "><", content)
     content = content.strip()
     for i, block in enumerate(blocks):

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -78,6 +78,12 @@ static bool isTrackedLcdWsConnection(const mg_connection *connection) {
     return false;
 }
 
+static void closeHttpConnectionAfterResponseIfNeeded(struct mg_connection *c, bool underPressure) {
+    if (c != nullptr && !c->is_websocket && underPressure) {
+        c->is_draining = 1;
+    }
+}
+
 static void sendWsError(struct mg_connection *c, const char *reason) {
     DynamicJsonDocument response(96);
     response["error"] = reason;
@@ -1781,6 +1787,7 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                 mg_http_serve_dir(c, hm, &opts);
             }
         }
+        closeHttpConnectionAfterResponseIfNeeded(c, nconns >= MAX_HTTP_CONNECTIONS);
     } // handle_URI
     // request is static, no delete needed
   } //HTTP request received

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -78,6 +78,12 @@ static bool isTrackedLcdWsConnection(const mg_connection *connection) {
     return false;
 }
 
+static void closeHttpConnectionAfterResponseIfNeeded(struct mg_connection *c, bool underPressure) {
+    if (c != nullptr && !c->is_websocket && underPressure) {
+        c->is_draining = 1;
+    }
+}
+
 static void sendWsError(struct mg_connection *c, const char *reason) {
     DynamicJsonDocument response(96);
     response["error"] = reason;
@@ -1346,13 +1352,18 @@ R"EOF(
 )EOF";
 
 
-// Maximum concurrent HTTP connections to prevent socket exhaustion
+// Maximum number of accepted inbound HTTP server connections we allow to stay active.
+// Keep one extra accepted slot available so a pending /ws/lcd upgrade still has a chance
+// to reach MG_EV_HTTP_MSG even when Safari briefly fans out multiple connections.
 #define MAX_HTTP_CONNECTIONS 8
+#define WS_CONNECTION_RESERVE 1
 
-// Count active connections in the manager
-static int countConnections(struct mg_mgr *mgr) {
+// Count accepted inbound server connections, excluding listeners and outbound clients.
+static int countServerConnections(struct mg_mgr *mgr) {
   int n = 0;
-  for (struct mg_connection *t = mgr->conns; t != NULL; t = t->next) n++;
+  for (struct mg_connection *t = mgr->conns; t != NULL; t = t->next) {
+    if (t->is_accepted && !t->is_client && !t->is_listening && !t->is_closing) n++;
+  }
   return n;
 }
 
@@ -1362,10 +1373,11 @@ static int countConnections(struct mg_mgr *mgr) {
 // fn_data is NULL for plain HTTP, and non-NULL for HTTPS
 static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
   if (ev == MG_EV_ACCEPT) {
-    // Limit concurrent connections to prevent socket exhaustion
-    int nconns = countConnections(c->mgr);
-    if (nconns > MAX_HTTP_CONNECTIONS) {
-      _LOG_W("Too many connections (%d), rejecting new connection\n", nconns);
+    // Limit concurrent accepted server connections, but keep one spare slot so a
+    // WebSocket upgrade can still reach MG_EV_HTTP_MSG under browser burstiness.
+    int nconns = countServerConnections(c->mgr);
+    if (nconns > (MAX_HTTP_CONNECTIONS + WS_CONNECTION_RESERVE)) {
+      _LOG_W("Too many accepted server connections (%d), rejecting new connection\n", nconns);
       c->is_closing = 1;  // Immediately close the connection
       return;
     }
@@ -1420,11 +1432,21 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
     // Binary messages are ignored (only server sends binary BMP images)
   } else if (ev == MG_EV_HTTP_MSG) {  // New HTTP request received
     struct mg_http_message *hm = (struct mg_http_message *) ev_data;            // Parsed HTTP request
+    const int nconns = countServerConnections(c->mgr);
 
     // Check for websocket upgrade request for LCD image stream
     if (mg_match(hm->uri, mg_str("/ws/lcd"), NULL)) {
+        _LOG_V("Allowing /ws/lcd upgrade with %d accepted server connections\n", nconns);
         mg_ws_upgrade(c, hm, NULL);  // Upgrade HTTP to WebSocket
         return;  // Don't process as regular HTTP
+    }
+
+    if (nconns > MAX_HTTP_CONNECTIONS) {
+        _LOG_W("HTTP connection limit reached (%d), reserving slot for WebSocket upgrade\n", nconns);
+        mg_http_reply(c, 503, "Connection: close\r\nContent-Type: text/plain\r\n",
+                      "Server busy, retry shortly");
+        c->is_draining = 1;
+        return;
     }
 
     static webServerRequest requestObj;  // Static to avoid heap allocation on every request
@@ -1767,6 +1789,7 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                 mg_http_serve_dir(c, hm, &opts);
             }
         }
+        closeHttpConnectionAfterResponseIfNeeded(c, nconns > MAX_HTTP_CONNECTIONS);
     } // handle_URI
     // request is static, no delete needed
   } //HTTP request received

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -78,12 +78,6 @@ static bool isTrackedLcdWsConnection(const mg_connection *connection) {
     return false;
 }
 
-static void closeHttpConnectionAfterResponseIfNeeded(struct mg_connection *c, bool underPressure) {
-    if (c != nullptr && !c->is_websocket && underPressure) {
-        c->is_draining = 1;
-    }
-}
-
 static void sendWsError(struct mg_connection *c, const char *reason) {
     DynamicJsonDocument response(96);
     response["error"] = reason;
@@ -1352,14 +1346,12 @@ R"EOF(
 )EOF";
 
 
-// Maximum number of accepted inbound HTTP server connections we allow to stay active.
-// Keep one extra accepted slot available so a pending /ws/lcd upgrade still has a chance
-// to reach MG_EV_HTTP_MSG even when Safari briefly fans out multiple connections.
+// Maximum concurrent HTTP connections to prevent socket exhaustion
 #define MAX_HTTP_CONNECTIONS 8
 #define WS_CONNECTION_RESERVE 1
 
-// Count accepted inbound server connections, excluding listeners and outbound clients.
-static int countServerConnections(struct mg_mgr *mgr) {
+// Count active connections
+static int countConnections(struct mg_mgr *mgr) {
   int n = 0;
   for (struct mg_connection *t = mgr->conns; t != NULL; t = t->next) {
     if (t->is_accepted && !t->is_client && !t->is_listening && !t->is_closing) n++;
@@ -1373,11 +1365,10 @@ static int countServerConnections(struct mg_mgr *mgr) {
 // fn_data is NULL for plain HTTP, and non-NULL for HTTPS
 static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
   if (ev == MG_EV_ACCEPT) {
-    // Limit concurrent accepted server connections, but keep one spare slot so a
-    // WebSocket upgrade can still reach MG_EV_HTTP_MSG under browser burstiness.
-    int nconns = countServerConnections(c->mgr);
+    // Limit concurrent connections to prevent socket exhaustion
+    int nconns = countConnections(c->mgr);
     if (nconns > (MAX_HTTP_CONNECTIONS + WS_CONNECTION_RESERVE)) {
-      _LOG_W("Too many accepted server connections (%d), rejecting new connection\n", nconns);
+      _LOG_W("Too many connections (%d), rejecting new connection\n", nconns);
       c->is_closing = 1;  // Immediately close the connection
       return;
     }
@@ -1432,17 +1423,15 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
     // Binary messages are ignored (only server sends binary BMP images)
   } else if (ev == MG_EV_HTTP_MSG) {  // New HTTP request received
     struct mg_http_message *hm = (struct mg_http_message *) ev_data;            // Parsed HTTP request
-    const int nconns = countServerConnections(c->mgr);
 
     // Check for websocket upgrade request for LCD image stream
     if (mg_match(hm->uri, mg_str("/ws/lcd"), NULL)) {
-        _LOG_V("Allowing /ws/lcd upgrade with %d accepted server connections\n", nconns);
         mg_ws_upgrade(c, hm, NULL);  // Upgrade HTTP to WebSocket
         return;  // Don't process as regular HTTP
     }
 
+    const int nconns = countConnections(c->mgr);
     if (nconns > MAX_HTTP_CONNECTIONS) {
-        _LOG_W("HTTP connection limit reached (%d), reserving slot for WebSocket upgrade\n", nconns);
         mg_http_reply(c, 503, "Connection: close\r\nContent-Type: text/plain\r\n",
                       "Server busy, retry shortly");
         c->is_draining = 1;
@@ -1789,7 +1778,6 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                 mg_http_serve_dir(c, hm, &opts);
             }
         }
-        closeHttpConnectionAfterResponseIfNeeded(c, nconns > MAX_HTTP_CONNECTIONS);
     } // handle_URI
     // request is static, no delete needed
   } //HTTP request received

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -78,12 +78,6 @@ static bool isTrackedLcdWsConnection(const mg_connection *connection) {
     return false;
 }
 
-static void closeHttpConnectionAfterResponseIfNeeded(struct mg_connection *c, bool underPressure) {
-    if (c != nullptr && !c->is_websocket && underPressure) {
-        c->is_draining = 1;
-    }
-}
-
 static void sendWsError(struct mg_connection *c, const char *reason) {
     DynamicJsonDocument response(96);
     response["error"] = reason;
@@ -1787,7 +1781,6 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                 mg_http_serve_dir(c, hm, &opts);
             }
         }
-        closeHttpConnectionAfterResponseIfNeeded(c, nconns >= MAX_HTTP_CONNECTIONS);
     } // handle_URI
     // request is static, no delete needed
   } //HTTP request received

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -1350,7 +1350,10 @@ R"EOF(
 #define MAX_HTTP_CONNECTIONS 8
 #define WS_CONNECTION_RESERVE 1
 
-// Count active connections
+// Count only accepted inbound server connections.
+// (This does not count listeners, outbound client connections,
+// or connections already closing, so the connection limit reflects actual
+// in-use HTTP/WebSocket server slots more accurately).
 static int countConnections(struct mg_mgr *mgr) {
   int n = 0;
   for (struct mg_connection *t = mgr->conns; t != NULL; t = t->next) {


### PR DESCRIPTION
Bugfix for WebSocket connection problem (on mobile Safari and others).

**Server code**

* Changed the HTTP connection limiting so only real inbound server connections are counted, reserves capacity for the LCD WebSocket and returns 503 for excess HTTP requests instead of starving the WebSocket.
* Updates packfs.py minification to stay conservative while removing HTML comments and inline JS block comments.

**Frontend code**

* Replaced the spinner with clearer connection/retry/error states, so it’s more obvious what is going on.
* Removed the logic to handle WebSocket pause when the tab is invisible (it made the code too complex!)
* Fixed an issue in the LCD unlock code. It was possible to unlock with an empty value. Now extra check on length.