### PR TITLE
Generalized support for networked meters and expanded HomeWizard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Communication between the SmartEVSE(s) / Sensorbox or kWh meters is done over RS
 - Automatically selects current capacity of the connected cable (13/16/32A)
 - Locking actuator support, locks the charging cable in the socket.
 - RFID reader support, restrict the use of the charging station to max 100 RFID cards.
-- An optional modbus kWh meter will measure power and energy, and display this on the LCD.
+- An optional modbus or networked kWh meter will measure power and energy, and display this on the LCD.
 - Built-in temperature sensor.
 - RGB led output for status information while charging.
 - All module parameters can be configured using the display and buttons.

--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -385,6 +385,12 @@
               $('.with_mainsmeter').hide();
             } else {
               $('.with_mainsmeter').show();
+              if ((data.mains_meter && data.mains_meter.host || '').trim()) {
+                $('#mainsmeter_host').text(mainsHost);
+                $('[id=with_mainsmeter_host]').show();
+              } else {
+                $('[id=with_mainsmeter_host]').hide();
+              }
             }
 
             if(data.ev_meter.description == "Disabled") {
@@ -392,6 +398,12 @@
             } else {
               $('[id=with_evmeter]').show();
               $('#evmeter_description').text(data.ev_meter.description);
+              if ((data.ev_meter.host || '').trim()) {
+                $('#evmeter_host').text(data.ev_meter.host);
+                $('[id=with_evmeter_host]').show();
+              } else {
+                $('[id=with_evmeter_host]').hide();
+              }
               $('#evmeter_power').text((data.ev_meter.import_active_power/1000).toFixed(1) + " kW");
               $('#evmeter_total_kwh').text((data.ev_meter.total_wh/1000).toFixed(1) + " kWh");
               $('#evmeter_charged_kwh').text((data.ev_meter.charged_wh/1000).toFixed(1) + " kWh");
@@ -1315,6 +1327,14 @@
                                           <div class="h5 mb-0 mr-3 text-gray-800" id="p1_data_time" style="text-align: right;"></div>
                                         </div>
                                     </div>
+                                    <div class="row no-gutters align-items-center" id="with_mainsmeter_host" style="display: none;">
+                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
+                                          Hostname:
+                                        </div>
+                                        <div class="col">
+                                          <div class="h5 mb-0 mr-3 text-gray-800" id="mainsmeter_host" style="text-align: right;"></div>
+                                        </div>
+                                    </div>
                                 </div>
                                 <div class="col-auto">
                                     <i class="fas fa-clipboard-list fa-2x text-gray-300">
@@ -1393,6 +1413,14 @@
                                     </div>
                                     <div class="col">
                                       <div class="h5 mb-0 mr-3 text-gray-800" id="evmeter_description" style="text-align: right;"></div>
+                                    </div>
+                                </div>
+                                <div class="row no-gutters align-items-center" id="with_evmeter_host" style="display: none;">
+                                  <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
+                                      Hostname:
+                                    </div>
+                                    <div class="col">
+                                      <div class="h5 mb-0 mr-3 text-gray-800" id="evmeter_host" style="text-align: right;"></div>
                                     </div>
                                 </div>
                                 <div class="row no-gutters align-items-center">

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -3764,29 +3764,25 @@ bool fwNeedsUpdate(char * version) {
   *
   * This function ensures a delay of at least 1.95 seconds between consecutive data retrieval attempts.
   */
- void homewizard_loop() {
-    static unsigned long lastCheck_homewizard = 0;
+static bool homewizardUpdateInProgress = false;
 
-    constexpr unsigned long interval = 1950; // 1.95 seconds - With this setting there can be 5 attempts for updating the data before the 10 second Mains Meter timeout.
-    const unsigned long currentTime = millis();
+static void homewizard_task(void *parameter) {
+    _LOG_A("homewizard_task(): started\n");
 
-    if (currentTime - lastCheck_homewizard < interval) {
-        return;
-    }
-    lastCheck_homewizard = currentTime;
     if (strlen(MainsMeter.DeviceHostName) == 0 && MainsMeter.Type == EM_HOMEWIZARD && LoadBl < 2) { //Mains Initialize
-        // Prevent existing HomeWizard P1 users from having to reconfigure their meter after updating to a version with the new HomeWizard Kwh implementation. 
+        // Prevent existing HomeWizard P1 users from having to reconfigure their meter after updating to a version with the new HomeWizard Kwh implementation.
         // We can remove this code after a few releases, when we are sure most users have updated at least once.
         _LOG_A("homewizard_loop(): Migrating HomeWizard P1 implementation");
-        //Old implementation just picked the first p1meter entry discovered, so we do the same here 
-        const mDNSServiceEntry *service = getmDNSServiceByIndex(EM_HOMEWIZARD, String("p1meter-"), 0, true); 
+        //Old implementation just picked the first p1meter entry discovered, so we do the same here
+        const mDNSServiceEntry *service = getmDNSServiceByIndex(EM_HOMEWIZARD, String("p1meter-"), 0, true);
         if (service != nullptr) {
             strncpy(MainsMeter.DeviceHostName, service->HostName.c_str(), sizeof(MainsMeter.DeviceHostName));
             MainsMeter.DeviceHostName[sizeof(MainsMeter.DeviceHostName) - 1] = '\0';
             write_settings();
         }
     }
-    if (MainsMeter.Type == EM_HOMEWIZARD && LoadBl < 2){ 
+
+    if (MainsMeter.Type == EM_HOMEWIZARD && LoadBl < 2) {
         _LOG_A("homewizard_loop(): start HomeWizard MainsMeter reading.");
         const auto evdata = getDataFromHomeWizard(MainsMeter.DeviceHostName);
 #if SMARTEVSE_VERSION < 40 //v3
@@ -3806,7 +3802,7 @@ bool fwNeedsUpdate(char * version) {
 #endif
     }
 
-    if (CircuitMeter.Type == EM_HOMEWIZARD){
+    if (CircuitMeter.Type == EM_HOMEWIZARD) {
         _LOG_A("homewizard_loop(): start HomeWizard CircuitMeter reading.");
         const auto evdata = getDataFromHomeWizard(CircuitMeter.DeviceHostName);
 #if SMARTEVSE_VERSION < 40 //v3
@@ -3826,7 +3822,7 @@ bool fwNeedsUpdate(char * version) {
 #endif
     }
 
-    if (EVMeter.Type == EM_HOMEWIZARD){
+    if (EVMeter.Type == EM_HOMEWIZARD) {
         _LOG_A("homewizard_loop(): start HomeWizard EVMeter reading.");
         const auto evdata = getDataFromHomeWizard(EVMeter.DeviceHostName);
 #if SMARTEVSE_VERSION < 40 //v3
@@ -3844,6 +3840,37 @@ bool fwNeedsUpdate(char * version) {
 #else
         Serial1.printf("@Irms:%03u,%d,%d,%d\n", EVMeter.Address, evdata.second[0], evdata.second[1], evdata.second[2]); //Irms:011,312,123,124 means: the meter on address 11(dec) has Irms[0] 312 dA, Irms[1] of 123 dA, Irms[2] of 124 dA
 #endif
+    }
+
+    homewizardUpdateInProgress = false;
+    _LOG_A("homewizard_task(): completed\n");
+    vTaskDelete(NULL);
+}
+
+ void homewizard_loop() {
+    static unsigned long lastCheck_homewizard = 0;
+
+    constexpr unsigned long interval = 1950; // 1.95 seconds - With this setting there can be 5 attempts for updating the data before the 10 second Mains Meter timeout.
+    const unsigned long currentTime = millis();
+
+    if (currentTime - lastCheck_homewizard < interval) {
+        return;
+    }
+    if (homewizardUpdateInProgress) {
+        return;
+    }
+    lastCheck_homewizard = currentTime;
+
+    homewizardUpdateInProgress = true;
+    if (xTaskCreate(
+            homewizard_task,
+            "HomeWizard",
+            8192,
+            NULL,
+            1,
+            NULL) != pdPASS) {
+        _LOG_A("homewizard_loop(): Failed to create HomeWizard task\n");
+        homewizardUpdateInProgress = false;
     }
 }
 

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -1108,6 +1108,8 @@ void mqttPublishData() {
             MQTTclient.publish(MQTTprefix + "/RFIDLastRead", buf, true, 0);
         }
         MQTTclient.publish(MQTTprefix + "/State", getStateNameWeb(State), true, 0);
+        //try evcc.io 
+		MQTTclient.publish(MQTTprefix + "/StateID", getStateName(State), true, 0);
         MQTTclient.publish(MQTTprefix + "/Error", getErrorNameWeb(ErrorFlags), true, 0);
         MQTTclient.publish(MQTTprefix + "/EVPlugState", (pilot != PILOT_12V) ? "Connected" : "Disconnected", true, 0);
         MQTTclient.publish(MQTTprefix + "/WiFiSSID", String(WiFi.SSID()), true, 0);
@@ -3767,12 +3769,12 @@ bool fwNeedsUpdate(char * version) {
 static bool homewizardUpdateInProgress = false;
 
 static void homewizard_task(void *parameter) {
-    _LOG_A("homewizard_task(): started\n");
+    _LOG_A("Started\n");
 
     if (strlen(MainsMeter.DeviceHostName) == 0 && MainsMeter.Type == EM_HOMEWIZARD && LoadBl < 2) { //Mains Initialize
         // Prevent existing HomeWizard P1 users from having to reconfigure their meter after updating to a version with the new HomeWizard Kwh implementation.
         // We can remove this code after a few releases, when we are sure most users have updated at least once.
-        _LOG_A("homewizard_loop(): Migrating HomeWizard P1 implementation");
+        _LOG_A("Migrating HomeWizard P1 implementation");
         //Old implementation just picked the first p1meter entry discovered, so we do the same here
         const mDNSServiceEntry *service = getmDNSServiceByIndex(EM_HOMEWIZARD, String("p1meter-"), 0, true);
         if (service != nullptr) {
@@ -3783,7 +3785,7 @@ static void homewizard_task(void *parameter) {
     }
 
     if (MainsMeter.Type == EM_HOMEWIZARD && LoadBl < 2) {
-        _LOG_A("homewizard_loop(): start HomeWizard MainsMeter reading.");
+        _LOG_A("Start HomeWizard MainsMeter reading.");
         const auto evdata = getDataFromHomeWizard(MainsMeter.DeviceHostName);
 #if SMARTEVSE_VERSION < 40 //v3
         for (int i = 0; i < evdata.first; i++)
@@ -3795,7 +3797,7 @@ static void homewizard_task(void *parameter) {
             MainsMeter.Export_active_energy = evdata.second[4];
             MainsMeter.PowerMeasured = evdata.second[5];
             MainsMeter.UpdateEnergies();
-            _LOG_A("homewizard_loop(): updated MainsMeter with Irms: %d, %d, %d, ActiveEnergyImport: %u, ActiveEnergyExport: %u, PowerMeasured: %u.\n", evdata.second[0], evdata.second[1], evdata.second[2], evdata.second[3], evdata.second[4], evdata.second[5]);
+            _LOG_A("Updated MainsMeter with Irms: %d, %d, %d, ActiveEnergyImport: %u, ActiveEnergyExport: %u, PowerMeasured: %u.\n", evdata.second[0], evdata.second[1], evdata.second[2], evdata.second[3], evdata.second[4], evdata.second[5]);
         }
 #else
         Serial1.printf("@Irms:%03u,%d,%d,%d\n", MainsMeter.Address, evdata.second[0], evdata.second[1], evdata.second[2]); //Irms:011,312,123,124 means: the meter on address 11(dec) has Irms[0] 312 dA, Irms[1] of 123 dA, Irms[2] of 124 dA
@@ -3803,7 +3805,7 @@ static void homewizard_task(void *parameter) {
     }
 
     if (CircuitMeter.Type == EM_HOMEWIZARD) {
-        _LOG_A("homewizard_loop(): start HomeWizard CircuitMeter reading.");
+        _LOG_A("Start HomeWizard CircuitMeter reading.");
         const auto evdata = getDataFromHomeWizard(CircuitMeter.DeviceHostName);
 #if SMARTEVSE_VERSION < 40 //v3
         for (int i = 0; i < evdata.first; i++)
@@ -3815,7 +3817,7 @@ static void homewizard_task(void *parameter) {
             CircuitMeter.Export_active_energy = evdata.second[4];
             CircuitMeter.PowerMeasured = evdata.second[5];
             CircuitMeter.UpdateEnergies();
-            _LOG_A("homewizard_loop(): updated CircuitMeter with Irms: %d, %d, %d, ActiveEnergyImport: %u, ActiveEnergyExport: %u, PowerMeasured: %u.\n", evdata.second[0], evdata.second[1], evdata.second[2], evdata.second[3], evdata.second[4], evdata.second[5]);
+            _LOG_A("Updated CircuitMeter with Irms: %d, %d, %d, ActiveEnergyImport: %u, ActiveEnergyExport: %u, PowerMeasured: %u.\n", evdata.second[0], evdata.second[1], evdata.second[2], evdata.second[3], evdata.second[4], evdata.second[5]);
         }
 #else
         Serial1.printf("@Irms:%03u,%d,%d,%d\n", CircuitMeter.Address, evdata.second[0], evdata.second[1], evdata.second[2]); //Irms:011,312,123,124 means: the meter on address 11(dec) has Irms[0] 312 dA, Irms[1] of 123 dA, Irms[2] of 124 dA
@@ -3823,7 +3825,7 @@ static void homewizard_task(void *parameter) {
     }
 
     if (EVMeter.Type == EM_HOMEWIZARD) {
-        _LOG_A("homewizard_loop(): start HomeWizard EVMeter reading.");
+        _LOG_A("Start HomeWizard EVMeter reading.");
         const auto evdata = getDataFromHomeWizard(EVMeter.DeviceHostName);
 #if SMARTEVSE_VERSION < 40 //v3
         for (int i = 0; i < evdata.first; i++)
@@ -3835,7 +3837,7 @@ static void homewizard_task(void *parameter) {
             EVMeter.Export_active_energy = evdata.second[4];
             EVMeter.PowerMeasured = evdata.second[5];
             EVMeter.UpdateEnergies();
-            _LOG_A("homewizard_loop(): updated EVMeter with Irms: %d, %d, %d, ActiveEnergyImport: %u, ActiveEnergyExport: %u, PowerMeasured: %u.\n", evdata.second[0], evdata.second[1], evdata.second[2], evdata.second[3], evdata.second[4], evdata.second[5]);
+            _LOG_A("Updated EVMeter with Irms: %d, %d, %d, ActiveEnergyImport: %u, ActiveEnergyExport: %u, PowerMeasured: %u.\n", evdata.second[0], evdata.second[1], evdata.second[2], evdata.second[3], evdata.second[4], evdata.second[5]);
         }
 #else
         Serial1.printf("@Irms:%03u,%d,%d,%d\n", EVMeter.Address, evdata.second[0], evdata.second[1], evdata.second[2]); //Irms:011,312,123,124 means: the meter on address 11(dec) has Irms[0] 312 dA, Irms[1] of 123 dA, Irms[2] of 124 dA
@@ -3843,7 +3845,7 @@ static void homewizard_task(void *parameter) {
     }
 
     homewizardUpdateInProgress = false;
-    _LOG_A("homewizard_task(): completed\n");
+    _LOG_A("Completed\n");
     vTaskDelete(NULL);
 }
 
@@ -3869,7 +3871,7 @@ static void homewizard_task(void *parameter) {
             NULL,
             1,
             NULL) != pdPASS) {
-        _LOG_A("homewizard_loop(): Failed to create HomeWizard task\n");
+        _LOG_A("Failed to create HomeWizard task\n");
         homewizardUpdateInProgress = false;
     }
 }

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -3867,7 +3867,7 @@ static void homewizard_task(void *parameter) {
     if (xTaskCreate(
             homewizard_task,
             "HomeWizard",
-            8192,
+            3072,
             NULL,
             1,
             NULL) != pdPASS) {

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -144,6 +144,9 @@ struct SettingsCache {
     uint16_t StartCurrent, StopTime, ImportCurrent;
     uint8_t Grid, SB2_WIFImode, RFIDReader;
     uint8_t MainsMeterType, MainsMeterAddress, EVMeterType, EVMeterAddress, CircuitMeterType, CircuitMeterAddress;
+    char MainsMeterDeviceHostName[32];
+    char EVMeterDeviceHostName[32];
+    char CircuitMeterDeviceHostName[32];
     uint8_t EMEndianness, EMIDivisor, EMUDivisor, EMPDivisor, EMEDivisor, EMDataType, EMFunction;
     uint16_t EMIRegister, EMURegister, EMPRegister, EMERegister;
     uint8_t WIFImode;
@@ -1104,8 +1107,6 @@ void mqttPublishData() {
             MQTTclient.publish(MQTTprefix + "/RFIDLastRead", buf, true, 0);
         }
         MQTTclient.publish(MQTTprefix + "/State", getStateNameWeb(State), true, 0);
-		//try evcc.io 
-		MQTTclient.publish(MQTTprefix + "/StateID", getStateName(State), true, 0);
         MQTTclient.publish(MQTTprefix + "/Error", getErrorNameWeb(ErrorFlags), true, 0);
         MQTTclient.publish(MQTTprefix + "/EVPlugState", (pilot != PILOT_12V) ? "Connected" : "Disconnected", true, 0);
         MQTTclient.publish(MQTTprefix + "/WiFiSSID", String(WiFi.SSID()), true, 0);
@@ -1242,7 +1243,7 @@ void validate_settings(void) {
 #if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40
     // If the address of the MainsMeter or EVmeter on a Node has changed, we must re-register the Modbus workers.
     if (LoadBl > 1) {
-        if (EVMeter.Type && EVMeter.Type != EM_API) MBserver.registerWorker(EVMeter.Address, ANY_FUNCTION_CODE, &MBEVMeterResponse);
+        if (EVMeter.Type && EVMeter.Type != EM_API && EVMeter.Type != EM_HOMEWIZARD) MBserver.registerWorker(EVMeter.Address, ANY_FUNCTION_CODE, &MBEVMeterResponse);
     }
 #endif
     MainsMeter.setTimeout(COMM_TIMEOUT);
@@ -1364,10 +1365,16 @@ void read_settings() {
 
         MainsMeter.Type = preferences.getUChar("MainsMeter", MAINS_METER);
         MainsMeter.Address = preferences.getUChar("MainsMAddress",MAINS_METER_ADDRESS);
+        strncpy(MainsMeter.DeviceHostName, preferences.getString("MainsHostName", "").c_str(), sizeof(MainsMeter.DeviceHostName));
+        MainsMeter.DeviceHostName[sizeof(MainsMeter.DeviceHostName) - 1] = '\0';
         EVMeter.Type = preferences.getUChar("EVMeter",EV_METER);
         EVMeter.Address = preferences.getUChar("EVMeterAddress",EV_METER_ADDRESS);
+        strncpy(EVMeter.DeviceHostName, preferences.getString("EVMeterHostName", "").c_str(), sizeof(EVMeter.DeviceHostName));
+        EVMeter.DeviceHostName[sizeof(EVMeter.DeviceHostName) - 1] = '\0';
         CircuitMeter.Type = preferences.getUChar("CircuitMeter",CIRCUIT_METER);
         CircuitMeter.Address = preferences.getUChar("CircuitMAddress",CIRCUIT_METER_ADDRESS);
+        strncpy(CircuitMeter.DeviceHostName, preferences.getString("CircuitHostName", "").c_str(), sizeof(CircuitMeter.DeviceHostName));
+        CircuitMeter.DeviceHostName[sizeof(CircuitMeter.DeviceHostName) - 1] = '\0';
         EMConfig[EM_CUSTOM].Endianness = preferences.getUChar("EMEndianness",EMCUSTOM_ENDIANESS);
         EMConfig[EM_CUSTOM].IRegister = preferences.getUShort("EMIRegister",EMCUSTOM_IREGISTER);
         EMConfig[EM_CUSTOM].IDivisor = preferences.getUChar("EMIDivisor",EMCUSTOM_IDIVISOR);
@@ -1432,10 +1439,16 @@ void read_settings() {
         settingsCache.RFIDReader = RFIDReader;
         settingsCache.MainsMeterType = MainsMeter.Type;
         settingsCache.MainsMeterAddress = MainsMeter.Address;
+        strncpy(settingsCache.MainsMeterDeviceHostName, MainsMeter.DeviceHostName, sizeof(settingsCache.MainsMeterDeviceHostName));
+        settingsCache.MainsMeterDeviceHostName[sizeof(settingsCache.MainsMeterDeviceHostName) - 1] = '\0';
         settingsCache.EVMeterType = EVMeter.Type;
         settingsCache.EVMeterAddress = EVMeter.Address;
+        strncpy(settingsCache.EVMeterDeviceHostName, EVMeter.DeviceHostName, sizeof(settingsCache.EVMeterDeviceHostName));
+        settingsCache.EVMeterDeviceHostName[sizeof(settingsCache.EVMeterDeviceHostName) - 1] = '\0';
         settingsCache.CircuitMeterType = CircuitMeter.Type;
         settingsCache.CircuitMeterAddress = CircuitMeter.Address;
+        strncpy(settingsCache.CircuitMeterDeviceHostName, CircuitMeter.DeviceHostName, sizeof(settingsCache.CircuitMeterDeviceHostName));
+        settingsCache.CircuitMeterDeviceHostName[sizeof(settingsCache.CircuitMeterDeviceHostName) - 1] = '\0';
         settingsCache.EMEndianness = EMConfig[EM_CUSTOM].Endianness;
         settingsCache.EMIRegister = EMConfig[EM_CUSTOM].IRegister;
         settingsCache.EMIDivisor = EMConfig[EM_CUSTOM].IDivisor;
@@ -1505,8 +1518,23 @@ void write_settings(void) {
 
     PREFS_PUT_UCHAR_IF_CHANGED("MainsMeter", MainsMeter.Type, MainsMeterType);
     PREFS_PUT_UCHAR_IF_CHANGED("MainsMAddress", MainsMeter.Address, MainsMeterAddress);
+        if (!settingsCache.valid || strcmp(MainsMeter.DeviceHostName, settingsCache.MainsMeterDeviceHostName) != 0) {
+        preferences.putString("MainsHostName", MainsMeter.DeviceHostName);
+        strncpy(settingsCache.MainsMeterDeviceHostName, MainsMeter.DeviceHostName, sizeof(settingsCache.MainsMeterDeviceHostName));
+        settingsCache.MainsMeterDeviceHostName[sizeof(settingsCache.MainsMeterDeviceHostName) - 1] = '\0';
+    }
     PREFS_PUT_UCHAR_IF_CHANGED("EVMeter", EVMeter.Type, EVMeterType);
     PREFS_PUT_UCHAR_IF_CHANGED("EVMeterAddress", EVMeter.Address, EVMeterAddress);
+    if (!settingsCache.valid || strcmp(EVMeter.DeviceHostName, settingsCache.EVMeterDeviceHostName) != 0) {
+        preferences.putString("EVMeterHostName", EVMeter.DeviceHostName);
+        strncpy(settingsCache.EVMeterDeviceHostName, EVMeter.DeviceHostName, sizeof(settingsCache.EVMeterDeviceHostName));
+        settingsCache.EVMeterDeviceHostName[sizeof(settingsCache.EVMeterDeviceHostName) - 1] = '\0';
+    }
+    if (!settingsCache.valid || strcmp(CircuitMeter.DeviceHostName, settingsCache.CircuitMeterDeviceHostName) != 0) {
+        preferences.putString("CircuitHostName", CircuitMeter.DeviceHostName);
+        strncpy(settingsCache.CircuitMeterDeviceHostName, CircuitMeter.DeviceHostName, sizeof(settingsCache.CircuitMeterDeviceHostName));
+        settingsCache.CircuitMeterDeviceHostName[sizeof(settingsCache.CircuitMeterDeviceHostName) - 1] = '\0';
+    }
     PREFS_PUT_UCHAR_IF_CHANGED("CircuitMeter", CircuitMeter.Type, CircuitMeterType);
     PREFS_PUT_UCHAR_IF_CHANGED("CircuitMAddress", CircuitMeter.Address, CircuitMeterAddress);
     PREFS_PUT_UCHAR_IF_CHANGED("EMEndianness", EMConfig[EM_CUSTOM].Endianness, EMEndianness);
@@ -1872,6 +1900,9 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
 
         doc["ev_meter"]["description"] = EMConfig[EVMeter.Type].Desc;
         doc["ev_meter"]["address"] = EVMeter.Address;
+        if (EVMeter.Type == EM_HOMEWIZARD) {
+            doc["ev_meter"]["host"] = strlen(EVMeter.DeviceHostName) > 0 ? EVMeter.DeviceHostName : "Not Set";
+        }
         doc["ev_meter"]["import_active_power"] = EVMeter.PowerMeasured; // Watt
         doc["ev_meter"]["total_wh"] = EVMeter.Energy; // Wh
         doc["ev_meter"]["charged_wh"] = EVMeter.EnergyCharged; // Wh
@@ -1879,6 +1910,7 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
         doc["ev_meter"]["currents"]["L1"] = EVMeter.Irms[0];
         doc["ev_meter"]["currents"]["L2"] = EVMeter.Irms[1];
         doc["ev_meter"]["currents"]["L3"] = EVMeter.Irms[2];
+
         if (EVMeter.Import_active_energy) //only export when not zero, because after boot it is zero = empty value
             doc["ev_meter"]["import_active_energy"] = EVMeter.Import_active_energy; // Wh
         if (EVMeter.Export_active_energy) //only export when not zero, because after boot it is zero = empty value
@@ -1888,15 +1920,21 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
             doc["mains_meter"]["import_active_energy"] = MainsMeter.Import_active_energy; // Wh
         if (MainsMeter.Export_active_energy) //only export when not zero, because after boot it is zero = empty value
             doc["mains_meter"]["export_active_energy"] = MainsMeter.Export_active_energy; // Wh
+        if (MainsMeter.Type == EM_HOMEWIZARD) {
+            doc["mains_meter"]["host"] = strlen(MainsMeter.DeviceHostName) > 0 ? MainsMeter.DeviceHostName : "Not Set";
+        }
         if (CircuitMeter.Type) {
+            doc["circuit_meter"]["description"] = EMConfig[CircuitMeter.Type].Desc;
+            doc["circuit_meter"]["address"] = CircuitMeter.Address;
+            if (CircuitMeter.Type == EM_HOMEWIZARD) {
+                doc["circuit_meter"]["host"] = strlen(CircuitMeter.DeviceHostName) > 0 ? CircuitMeter.DeviceHostName : "Not Set";
+            }
             doc["circuit_meter"]["currents"]["TOTAL"] = CircuitMeter.Irms[0] + CircuitMeter.Irms[1] + CircuitMeter.Irms[2];
             doc["circuit_meter"]["currents"]["L1"] = CircuitMeter.Irms[0];
             doc["circuit_meter"]["currents"]["L2"] = CircuitMeter.Irms[1];
             doc["circuit_meter"]["currents"]["L3"] = CircuitMeter.Irms[2];
         }
-        if (MainsMeter.Type == EM_HOMEWIZARD_P1) {
-            doc["mains_meter"]["host"] = !homeWizardHost.isEmpty() ? homeWizardHost : "HomeWizard P1 Not Found";
-        }
+
           
         doc["phase_currents"]["TOTAL"] = MainsMeter.Irms[0] + MainsMeter.Irms[1] + MainsMeter.Irms[2];
         doc["phase_currents"]["L1"] = MainsMeter.Irms[0];
@@ -3717,12 +3755,12 @@ bool fwNeedsUpdate(char * version) {
 }
 
 /**
-  * Periodically retrieves current measurements from the HomeWizard P1 energy meter
-  * and updates the main meter's currents.
+  * Periodically retrieves current measurements from networked energy meters
+  * and updates the meters' currents and energies.
   *
   * This function ensures a delay of at least 1.95 seconds between consecutive data retrieval attempts.
   */
- void homewizard_loop() {
+ void homewizard_loop(bool MainsInit,bool MainsEnabled, bool EVEnabled, bool CircuitEnabled) {
     static unsigned long lastCheck_homewizard = 0;
 
     constexpr unsigned long interval = 1950; // 1.95 seconds - With this setting there can be 5 attempts for updating the data before the 10 second Mains Meter timeout.
@@ -3731,29 +3769,89 @@ bool fwNeedsUpdate(char * version) {
     if (currentTime - lastCheck_homewizard < interval) {
         return;
     }
-
-    _LOG_A("homewizard_loop(): start HomeWizrd P1 reading.");
     lastCheck_homewizard = currentTime;
-
-    const auto currents = getMainsFromHomeWizardP1();
-#if SMARTEVSE_VERSION < 40 //v3
-    for (int i = 0; i < currents.first; i++)
-        MainsMeter.Irms[i] = currents.second[i];
-    if (currents.first) {
-        CalcIsum();
-        MainsMeter.setTimeout(COMM_TIMEOUT);
+    if (MainsInit && MainsEnabled) {
+        // Prevent existing HomeWizard P1 users from having to reconfigure their meter after updating to a version with the new HomeWizard Kwh implementation. 
+        // We can remove this code after a few releases, when we are sure most users have updated at least once.
+        _LOG_A("homewizard_loop(): Migrating HomeWizard P1 implementation");
+        //Old implementation just picked the first p1meter entry discovered, so we do the same here 
+        const mDNSServiceEntry *service = getmDNSServiceByIndex(EM_HOMEWIZARD, String("p1meter-"), 0, true); 
+        if (service != nullptr) {
+            strncpy(MainsMeter.DeviceHostName, service->HostName.c_str(), sizeof(MainsMeter.DeviceHostName));
+            MainsMeter.DeviceHostName[sizeof(MainsMeter.DeviceHostName) - 1] = '\0';
+            write_settings();
+        }
     }
+    if (MainsEnabled){
+        _LOG_A("homewizard_kwh_loop(): start HomeWizard Kwh reading.");
+        const auto evdata = getDataFromHomeWizard(MainsMeter.DeviceHostName);
+#if SMARTEVSE_VERSION < 40 //v3
+        for (int i = 0; i < evdata.first; i++)
+            MainsMeter.Irms[i] = evdata.second[i];
+        if (evdata.first) {
+            CalcIsum();
+            MainsMeter.setTimeout(COMM_TIMEOUT);
+            MainsMeter.Import_active_energy = evdata.second[3];
+            MainsMeter.Export_active_energy = evdata.second[4];
+            MainsMeter.PowerMeasured = evdata.second[5];
+            MainsMeter.UpdateEnergies();
+            _LOG_A("homewizard_loop(): updated MainsMeter with Irms: %d, %d, %d, ActiveEnergyImport: %u, ActiveEnergyExport: %u, PowerMeasured: %u.\n", evdata.second[0], evdata.second[1], evdata.second[2], evdata.second[3], evdata.second[4], evdata.second[5]);
+        }
 #else
-    Serial1.printf("@Irms:%03u,%d,%d,%d\n", MainsMeter.Address, currents.second[0], currents.second[1], currents.second[2]); //Irms:011,312,123,124 means: the meter on address 11(dec) has Irms[0] 312 dA, Irms[1] of 123 dA, Irms[2] of 124 dA
+        Serial1.printf("@Irms:%03u,%d,%d,%d\n", MainsMeter.Address, evdata.second[0], evdata.second[1], evdata.second[2]); //Irms:011,312,123,124 means: the meter on address 11(dec) has Irms[0] 312 dA, Irms[1] of 123 dA, Irms[2] of 124 dA
 #endif
+    }
+
+    if (CircuitEnabled){
+        _LOG_A("homewizard_kwh_loop(): start HomeWizard Kwh reading.");
+        const auto evdata = getDataFromHomeWizard(CircuitMeter.DeviceHostName);
+#if SMARTEVSE_VERSION < 40 //v3
+        for (int i = 0; i < evdata.first; i++)
+            CircuitMeter.Irms[i] = evdata.second[i];
+        if (evdata.first) {
+            CircuitMeter.CalcImeasured();
+            CircuitMeter.setTimeout(COMM_TIMEOUT);
+            CircuitMeter.Import_active_energy = evdata.second[3];
+            CircuitMeter.Export_active_energy = evdata.second[4];
+            CircuitMeter.PowerMeasured = evdata.second[5];
+            CircuitMeter.UpdateEnergies();
+            _LOG_A("homewizard_loop(): updated CircuitMeter with Irms: %d, %d, %d, ActiveEnergyImport: %u, ActiveEnergyExport: %u, PowerMeasured: %u.\n", evdata.second[0], evdata.second[1], evdata.second[2], evdata.second[3], evdata.second[4], evdata.second[5]);
+        }
+#else
+        Serial1.printf("@Irms:%03u,%d,%d,%d\n", CircuitMeter.Address, evdata.second[0], evdata.second[1], evdata.second[2]); //Irms:011,312,123,124 means: the meter on address 11(dec) has Irms[0] 312 dA, Irms[1] of 123 dA, Irms[2] of 124 dA
+#endif
+    }
+
+    if (EVEnabled){
+        _LOG_A("homewizard_kwh_loop(): start HomeWizard Kwh reading.");
+        const auto evdata = getDataFromHomeWizard(EVMeter.DeviceHostName);
+#if SMARTEVSE_VERSION < 40 //v3
+        for (int i = 0; i < evdata.first; i++)
+            EVMeter.Irms[i] = evdata.second[i];
+        if (evdata.first) {
+            EVMeter.CalcImeasured();
+            EVMeter.setTimeout(COMM_TIMEOUT);
+            EVMeter.Import_active_energy = evdata.second[3];
+            EVMeter.Export_active_energy = evdata.second[4];
+            EVMeter.PowerMeasured = evdata.second[5];
+            EVMeter.UpdateEnergies();
+            _LOG_A("homewizard_loop(): updated EVMeter with Irms: %d, %d, %d, ActiveEnergyImport: %u, ActiveEnergyExport: %u, PowerMeasured: %u.\n", evdata.second[0], evdata.second[1], evdata.second[2], evdata.second[3], evdata.second[4], evdata.second[5]);
+        }
+#else
+        Serial1.printf("@Irms:%03u,%d,%d,%d\n", EVMeter.Address, evdata.second[0], evdata.second[1], evdata.second[2]); //Irms:011,312,123,124 means: the meter on address 11(dec) has Irms[0] 312 dA, Irms[1] of 123 dA, Irms[2] of 124 dA
+#endif
+    }
 }
 
 void loop() {
 
     network_loop();
-    if (MainsMeter.Type == EM_HOMEWIZARD_P1 && LoadBl < 2) {
-        homewizard_loop();
-    }
+    homewizard_loop(
+        strlen(MainsMeter.DeviceHostName) == 0,
+        MainsMeter.Type == EM_HOMEWIZARD && LoadBl < 2,
+        EVMeter.Type == EM_HOMEWIZARD,
+        CircuitMeter.Type == EM_HOMEWIZARD
+    );
     
     static unsigned long lastCheck = 0;
     if (millis() - lastCheck >= 1000) {

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -1368,14 +1368,17 @@ void read_settings() {
         MainsMeter.Address = preferences.getUChar("MainsMAddress",MAINS_METER_ADDRESS);
         strncpy(MainsMeter.DeviceHostName, preferences.getString("MainsHostName", "").c_str(), sizeof(MainsMeter.DeviceHostName));
         MainsMeter.DeviceHostName[sizeof(MainsMeter.DeviceHostName) - 1] = '\0';
+        MainsMeter.HostMenuSelection = 0; // Ensure HostMenuSelection is initialized to 0 so Menu shows the current saved hostname
         EVMeter.Type = preferences.getUChar("EVMeter",EV_METER);
         EVMeter.Address = preferences.getUChar("EVMeterAddress",EV_METER_ADDRESS);
         strncpy(EVMeter.DeviceHostName, preferences.getString("EVMeterHostName", "").c_str(), sizeof(EVMeter.DeviceHostName));
         EVMeter.DeviceHostName[sizeof(EVMeter.DeviceHostName) - 1] = '\0';
+        EVMeter.HostMenuSelection = 0; // Ensure HostMenuSelection is initialized to 0 so Menu shows the current saved hostname
         CircuitMeter.Type = preferences.getUChar("CircuitMeter",CIRCUIT_METER);
         CircuitMeter.Address = preferences.getUChar("CircuitMAddress",CIRCUIT_METER_ADDRESS);
         strncpy(CircuitMeter.DeviceHostName, preferences.getString("CircuitHostName", "").c_str(), sizeof(CircuitMeter.DeviceHostName));
         CircuitMeter.DeviceHostName[sizeof(CircuitMeter.DeviceHostName) - 1] = '\0';
+        CircuitMeter.HostMenuSelection = 0; // Ensure HostMenuSelection is initialized to 0 so Menu shows the current saved hostname
         EMConfig[EM_CUSTOM].Endianness = preferences.getUChar("EMEndianness",EMCUSTOM_ENDIANESS);
         EMConfig[EM_CUSTOM].IRegister = preferences.getUShort("EMIRegister",EMCUSTOM_IREGISTER);
         EMConfig[EM_CUSTOM].IDivisor = preferences.getUChar("EMIDivisor",EMCUSTOM_IDIVISOR);

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -3760,7 +3760,7 @@ bool fwNeedsUpdate(char * version) {
   *
   * This function ensures a delay of at least 1.95 seconds between consecutive data retrieval attempts.
   */
- void homewizard_loop(bool MainsInit,bool MainsEnabled, bool EVEnabled, bool CircuitEnabled) {
+ void homewizard_loop() {
     static unsigned long lastCheck_homewizard = 0;
 
     constexpr unsigned long interval = 1950; // 1.95 seconds - With this setting there can be 5 attempts for updating the data before the 10 second Mains Meter timeout.
@@ -3770,7 +3770,7 @@ bool fwNeedsUpdate(char * version) {
         return;
     }
     lastCheck_homewizard = currentTime;
-    if (MainsInit && MainsEnabled) {
+    if (strlen(MainsMeter.DeviceHostName) == 0 && MainsMeter.Type == EM_HOMEWIZARD && LoadBl < 2) { //Mains Initialize
         // Prevent existing HomeWizard P1 users from having to reconfigure their meter after updating to a version with the new HomeWizard Kwh implementation. 
         // We can remove this code after a few releases, when we are sure most users have updated at least once.
         _LOG_A("homewizard_loop(): Migrating HomeWizard P1 implementation");
@@ -3782,8 +3782,8 @@ bool fwNeedsUpdate(char * version) {
             write_settings();
         }
     }
-    if (MainsEnabled){
-        _LOG_A("homewizard_kwh_loop(): start HomeWizard Kwh reading.");
+    if (MainsMeter.Type == EM_HOMEWIZARD && LoadBl < 2){ 
+        _LOG_A("homewizard_loop(): start HomeWizard MainsMeter reading.");
         const auto evdata = getDataFromHomeWizard(MainsMeter.DeviceHostName);
 #if SMARTEVSE_VERSION < 40 //v3
         for (int i = 0; i < evdata.first; i++)
@@ -3802,8 +3802,8 @@ bool fwNeedsUpdate(char * version) {
 #endif
     }
 
-    if (CircuitEnabled){
-        _LOG_A("homewizard_kwh_loop(): start HomeWizard Kwh reading.");
+    if (CircuitMeter.Type == EM_HOMEWIZARD){
+        _LOG_A("homewizard_loop(): start HomeWizard CircuitMeter reading.");
         const auto evdata = getDataFromHomeWizard(CircuitMeter.DeviceHostName);
 #if SMARTEVSE_VERSION < 40 //v3
         for (int i = 0; i < evdata.first; i++)
@@ -3822,8 +3822,8 @@ bool fwNeedsUpdate(char * version) {
 #endif
     }
 
-    if (EVEnabled){
-        _LOG_A("homewizard_kwh_loop(): start HomeWizard Kwh reading.");
+    if (EVMeter.Type == EM_HOMEWIZARD){
+        _LOG_A("homewizard_loop(): start HomeWizard EVMeter reading.");
         const auto evdata = getDataFromHomeWizard(EVMeter.DeviceHostName);
 #if SMARTEVSE_VERSION < 40 //v3
         for (int i = 0; i < evdata.first; i++)
@@ -3846,12 +3846,7 @@ bool fwNeedsUpdate(char * version) {
 void loop() {
 
     network_loop();
-    homewizard_loop(
-        strlen(MainsMeter.DeviceHostName) == 0,
-        MainsMeter.Type == EM_HOMEWIZARD && LoadBl < 2,
-        EVMeter.Type == EM_HOMEWIZARD,
-        CircuitMeter.Type == EM_HOMEWIZARD
-    );
+    homewizard_loop();
     
     static unsigned long lastCheck = 0;
     if (millis() - lastCheck >= 1000) {

--- a/SmartEVSE-3/src/esp32.h
+++ b/SmartEVSE-3/src/esp32.h
@@ -238,8 +238,6 @@ void setOverrideCurrent(uint16_t Current);
 void SetCPDuty(uint32_t DutyCycle);
 uint8_t setItemValue(uint8_t nav, uint16_t val);
 uint16_t getItemValue(uint8_t nav);
-void commitMeterHostSelection(uint8_t nav);
-void resetMeterHostSelections(void);
 void ConfigureModbusMode(uint8_t newmode);
 void setMode(uint8_t NewMode) ;
 void BuzzConfirmation(void);

--- a/SmartEVSE-3/src/esp32.h
+++ b/SmartEVSE-3/src/esp32.h
@@ -167,6 +167,7 @@ const struct {
     {"RFID",    "RFID reader, learn/remove cards",                    0, 5 + (ENABLE_OCPP ? 1 : 0), RFID_READER},
     {"EV METER","Type of EV electric meter",                          0, (uint16_t) (EMConfigSize / sizeof(EMConfig[0])-1), EV_METER},
     {"EV ADDR", "Address of EV electric meter",                       MIN_EV_METER_ADDRESS, MAX_METER_ADDRESS, EV_METER_ADDRESS},
+    {"EV HST", "Selected hostname or discovered hostname index",      0, 9, 0},
 
     // System configuration
     /* LCD,       Desc,                                                 Min, Max, Default */
@@ -180,8 +181,10 @@ const struct {
     {"IMPORT",  "Allow grid power when solar charging (sum of phase)",0, 48, IMPORT_CURRENT},
     {"MAINS MET","Type of mains electric meter",                      0, (uint16_t) (EMConfigSize / sizeof(EMConfig[0])-1), MAINS_METER},
     {"MAINS ADR","Address of mains electric meter",                   MIN_METER_ADDRESS, MAX_METER_ADDRESS, MAINS_METER_ADDRESS},
+    {"MAINS HST", "Selected hostname or discovered hostname index",   0, 9, 0},
     {"CIRCT MET","Type of circuit electric meter",                    0, (uint16_t) (EMConfigSize / sizeof(EMConfig[0])-1), CIRCUIT_METER},
     {"CIRCT ADR","Address of circuit electric meter",                 MIN_METER_ADDRESS, MAX_METER_ADDRESS, CIRCUIT_METER_ADDRESS},
+    {"CIRCT HST", "Selected hostname or discovered hostname index",   0, 9, 0},
     {"BYTE ORD","Byte order of custom electric meter",                0, 3, EMCUSTOM_ENDIANESS},
     {"DATA TYPE","Data type of custom electric meter",                 0, MB_DATATYPE_MAX - 1, EMCUSTOM_DATATYPE},
     {"FUNCTION","Modbus Function of custom electric meter",           3, 4, EMCUSTOM_FUNCTION},
@@ -235,6 +238,8 @@ void setOverrideCurrent(uint16_t Current);
 void SetCPDuty(uint32_t DutyCycle);
 uint8_t setItemValue(uint8_t nav, uint16_t val);
 uint16_t getItemValue(uint8_t nav);
+void commitMeterHostSelection(uint8_t nav);
+void resetMeterHostSelections(void);
 void ConfigureModbusMode(uint8_t newmode);
 void setMode(uint8_t NewMode) ;
 void BuzzConfirmation(void);

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -556,6 +556,7 @@ void GLCD(void) {
         if (LCDTimer > 120) {
             LCDNav = 0;                                                         // Exit Setup menu after 120 seconds.
             PairingPin = "";                                                    // Reset PairingPin when exiting menu.
+            resetMeterHostSelections();                                         // Drop pending host cursor on inactivity exit.
             read_settings();                                                    // don't save, but restore settings
         } else return;                                                          // disable LCD status messages when navigating LCD Menu
     } // if LCDNav
@@ -578,7 +579,7 @@ void GLCD(void) {
             } else if (ErrorFlags & CIRCUIT_NOCOMM) {
                 GLCD_print_buf2(0, (const char *) "CAN'T READ");
                 GLCD_print_buf2(2, (const char *) "CIRCUIT METER");
-            } else if (MainsMeter.Type == EM_API || MainsMeter.Type == EM_HOMEWIZARD_P1) {
+            } else if (MainsMeter.Type == EM_API || MainsMeter.Type == EM_HOMEWIZARD) {
                 GLCD_print_buf2(0, (const char *) "CAN'T READ");
                 GLCD_print_buf2(2, (const char *) "MAINS METER");
             } else {
@@ -1022,6 +1023,7 @@ const char * getMenuItemOption(uint8_t nav) {
     const static char StrGrid[2][10] = {"4Wire", "3Wire"};
     const static char StrEnabled[] = "Enabled";
     const static char StrExitMenu[] = "MENU";
+    const static char StrNotSet[] = "Not Set";
     extern const char StrRFIDReader[7][10];
     const static char StrWiFi[3][10] = {"Disabled", "Enabled", "SetupWifi"};
     const static char StrCapMode[][9] = {"Disabled", "Fixed", "Interval", "Flanders"};
@@ -1097,6 +1099,26 @@ const char * getMenuItemOption(uint8_t nav) {
         case MENU_LCDPIN:
             sprintf(Str, "%04u", value);
             return Str;
+        case MENU_EVMETERHOST:
+        case MENU_MAINSMETERHOST:
+        case MENU_CIRCUITMETERHOST: {
+            Meter *meter = getMeterByHostnameMenu(nav);
+            if (meter == nullptr) {
+                return StrNotSet;
+            }
+            if (value == 0) {
+                if (strlen(meter->DeviceHostName) == 0) return StrNotSet;
+                compileServiceName(meter->Type, meter->DeviceHostName, Str, sizeof(Str));
+                if (Str[0] == '\0') return StrNotSet;
+                return Str;
+            }
+            const mDNSServiceEntry *service = getCompatiblemDNSServiceByIndex(meter->Type, value - 1);
+            if (service && !service->Name.isEmpty()) {
+                snprintf(Str, sizeof(Str), "%s", service->Name.c_str());
+                return Str;
+            }
+            return StrNotSet;
+        }
         case MENU_MAINSMETERADDRESS:
         case MENU_EVMETERADDRESS:
         case MENU_CIRCUITMETERADDRESS:
@@ -1173,19 +1195,29 @@ uint8_t getMenuItems (void) {
                 if (SB2.SoftwareVer == 0x01 || SB2.SoftwareVer == 0x03) {
                     MenuItems[m++] = MENU_SB2_WIFI;                             // Sensorbox-2 Wifi  0:Disabled / 1:Enabled / 2:Portal
                 }
-            } else if (MainsMeter.Type && MainsMeter.Type != EM_API && MainsMeter.Type != EM_HOMEWIZARD_P1) { // - - ? Other?
+            } else if (MainsMeter.Type && MainsMeter.Type != EM_API && MainsMeter.Type != EM_HOMEWIZARD) { // - - ? Other?
                 MenuItems[m++] = MENU_MAINSMETERADDRESS;                        // - - - Address of Mains electric meter (9 - 247)
+            }
+            if (MainsMeter.Type && MainsMeter.Type == EM_HOMEWIZARD) {                           // - ? EV meter configured?
+                MenuItems[m++] = MENU_MAINSMETERHOST;                      // - - Device hostname selector for EV electric meter (0: current / 1-9 discovered hostnames)
             }
             MenuItems[m++] = MENU_CIRCUITMETER;                                 // - - Type of Circuit electric meter (0: Disabled / Constants EM_*)
             if (CircuitMeter.Type && CircuitMeter.Type != EM_API) {             // - ? Circuit meter configured?
                 MenuItems[m++] = MENU_CIRCUITMETERADDRESS;                      // - - Address of Circuit electric meter (9 - 247)
             }
+            if (CircuitMeter.Type && CircuitMeter.Type == EM_HOMEWIZARD) {                           // - ? EV meter configured?
+                MenuItems[m++] = MENU_CIRCUITMETERHOST;                      // - - Device hostname selector for EV electric meter (0: current / 1-9 discovered hostnames)
+            }
+            
             if (CircuitMeter.Type || LoadBl == 1)                               // old MaxCircuit behaviour without a CircuitMeter present: we will guard the max the Master gives out!
                 MenuItems[m++] = MENU_CIRCUIT;                                          // - Max current of the EVSE circuit (A)
         }
         MenuItems[m++] = MENU_EVMETER;                                          // - Type of EV electric meter (0: Disabled / Constants EM_*)
-        if (EVMeter.Type && EVMeter.Type != EM_API) {                           // - ? EV meter configured?
+        if (EVMeter.Type && EVMeter.Type != EM_API && EVMeter.Type != EM_HOMEWIZARD) {                           // - ? EV meter configured?
             MenuItems[m++] = MENU_EVMETERADDRESS;                               // - - Address of EV electric meter (9 - 247)
+        }
+        if (EVMeter.Type && EVMeter.Type == EM_HOMEWIZARD) {                           // - ? EV meter configured?
+            MenuItems[m++] = MENU_EVMETERHOST;                      // - - Device hostname selector for EV electric meter (0: current / 1-9 discovered hostnames)
         }
         if (LoadBl < 2) {                                                       // - ? Load Balancing Disabled/Master?
             if (MainsMeter.Type == EM_CUSTOM || EVMeter.Type == EM_CUSTOM || CircuitMeter.Type == EM_CUSTOM) { // ? Custom electric meter used?
@@ -1308,18 +1340,24 @@ void GLCDMenu(uint8_t Buttons) {
                 value = getItemValue(LCDNav);
                 switch (LCDNav) {
                     case MENU_MAINSMETER:
-                        do {
-                            value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
-                        } while (value == EM_UNUSED_SLOT4);
+                        value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
                         setItemValue(LCDNav, value);
                         break;
-                    case MENU_CIRCUITMETER:                                     // do not display the Sensorbox, HomeWizard P1 or unused slots here
-                    case MENU_EVMETER:                                          // do not display the Sensorbox, HomeWizard P1 or unused slots here
+                    case MENU_CIRCUITMETER:                                     // do not display the Sensorbox, HomeWizard P1/KWH or unused slots here
+                    case MENU_EVMETER:                                          // do not display the Sensorbox, HomeWizard P1/KWH or unused slots here
                         do {
                             value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
-                        } while (value == EM_SENSORBOX || value == EM_HOMEWIZARD_P1 || value == EM_UNUSED_SLOT4);
+                        } while (value == EM_SENSORBOX);
                         setItemValue(LCDNav, value);
                         break;
+                    case MENU_EVMETERHOST:
+                    case MENU_CIRCUITMETERHOST:
+                    case MENU_MAINSMETERHOST: {
+                        Meter *meter = getMeterByHostnameMenu(LCDNav);
+                        value = MenuNavInt(Buttons, value, 0, meter != nullptr ? getCompatiblemDNSServiceCount(meter->Type) : 0);
+                        setItemValue(LCDNav, value);
+                        break;
+                    }
                     case MENU_WIFI:
                         value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
                         setItemValue(LCDNav, value);
@@ -1385,6 +1423,9 @@ void GLCDMenu(uint8_t Buttons) {
     } else if (LCDNav > 1 && LCDNav != MENU_OFF && LCDNav != MENU_ON && Buttons == 0x5 && ButtonRelease == 0) {            // Button 2 pressed?
         ButtonRelease = 1;
         if (SubMenu) {                                                          // We are currently in Submenu
+            if (LCDNav == MENU_EVMETERHOST || LCDNav == MENU_MAINSMETERHOST || LCDNav == MENU_CIRCUITMETERHOST) {
+                commitMeterHostSelection(LCDNav);
+            }
             SubMenu = 0;                                                        // Exit Submenu now
             digit = 3;
             uint8_t WIFImode = getItemValue(MENU_WIFI);

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -1035,6 +1035,8 @@ static const char *getMeterHostStr(const Meter &meter, uint8_t value) {
  * @return void
  */
 static void commitMeterHostSelection(Meter &meter, uint8_t value) {
+    // If the user selected "Unchanged", do nothing and just clear the pending menu selection
+    // Else, if they selected an mDNS entry ( value >= 1 ), update the meter's DeviceHostName to match the selected entry
     if (value >= 1) {
         const mDNSServiceEntry *service = getCompatiblemDNSServiceByIndex(meter.Type, value - 1);
         if (service && !service->HostName.isEmpty()) {

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -1235,7 +1235,6 @@ uint8_t getMenuItems (void) {
             if (CircuitMeter.Type && CircuitMeter.Type == EM_HOMEWIZARD) {                           // - ? EV meter configured?
                 MenuItems[m++] = MENU_CIRCUITMETERHOST;                      // - - Device hostname selector for EV electric meter (0: current / 1-9 discovered hostnames)
             }
-            
             if (CircuitMeter.Type || LoadBl == 1)                               // old MaxCircuit behaviour without a CircuitMeter present: we will guard the max the Master gives out!
                 MenuItems[m++] = MENU_CIRCUIT;                                          // - Max current of the EVSE circuit (A)
         }
@@ -1367,14 +1366,16 @@ void GLCDMenu(uint8_t Buttons) {
                 value = getItemValue(LCDNav);
                 switch (LCDNav) {
                     case MENU_MAINSMETER:
-                        value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
+                        do {
+                            value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
+                        } while (value == EM_UNUSED_SLOT4);
                         setItemValue(LCDNav, value);
                         break;
                     case MENU_CIRCUITMETER:                                     // do not display the Sensorbox or unused slots here
                     case MENU_EVMETER:                                          // do not display the Sensorbox or unused slots here
                         do {
                             value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
-                        } while (value == EM_SENSORBOX);
+                        } while (value == EM_SENSORBOX || value == EM_UNUSED_SLOT4);
                         setItemValue(LCDNav, value);
                         break;
                     case MENU_EVMETERHOST:

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -556,7 +556,6 @@ void GLCD(void) {
         if (LCDTimer > 120) {
             LCDNav = 0;                                                         // Exit Setup menu after 120 seconds.
             PairingPin = "";                                                    // Reset PairingPin when exiting menu.
-            resetMeterHostSelections();                                         // Drop pending host cursor on inactivity exit.
             read_settings();                                                    // don't save, but restore settings
         } else return;                                                          // disable LCD status messages when navigating LCD Menu
     } // if LCDNav
@@ -1006,6 +1005,47 @@ void GLCD(void) {
  * @param uint8_t nav
  * @return uint8_t[] MenuItemOption
  */
+static const char *getMeterHostStr(const Meter &meter, uint8_t value) {
+    static char Str[12]; // must be declared static, since it's referenced outside of function scope
+
+    if (value == 0) {
+        if (strlen(meter.DeviceHostName) == 0) return "Not Set";
+        compileServiceName(meter.Type, meter.DeviceHostName, Str, sizeof(Str));
+        if (Str[0] == '\0') return "Not Set";
+        return Str;
+    }
+
+    const mDNSServiceEntry *service = getCompatiblemDNSServiceByIndex(meter.Type, value - 1);
+    if (service && !service->HostName.isEmpty()) {
+        compileServiceName(meter.Type, service->HostName.c_str(), Str, sizeof(Str));
+        if (Str[0] != '\0') {
+            return Str;
+        }
+    }
+    return "Not Set";
+}
+
+/**
+ * Commit the selected host entry for one meter menu.
+ * This only updates the meter that was actually edited, and clears that meter's
+ * pending menu selection so the LCD menu returns to its neutral state.
+ * 
+ * @param Meter &meter
+ * @param uint8_t menu selection index (0 for "Unchanged", 1 for first mDNS entry, etc.)
+ * @return void
+ */
+static void commitMeterHostSelection(Meter &meter, uint8_t value) {
+    if (value >= 1) {
+        const mDNSServiceEntry *service = getCompatiblemDNSServiceByIndex(meter.Type, value - 1);
+        if (service && !service->HostName.isEmpty()) {
+            strncpy(meter.DeviceHostName, service->HostName.c_str(), sizeof(meter.DeviceHostName));
+            meter.DeviceHostName[sizeof(meter.DeviceHostName) - 1] = '\0';
+        }
+    }
+
+    meter.HostMenuSelection = 0;
+}
+
 const char * getMenuItemOption(uint8_t nav) {
     static char Str[12]; // must be declared static, since it's referenced outside of function scope
 
@@ -1023,7 +1063,6 @@ const char * getMenuItemOption(uint8_t nav) {
     const static char StrGrid[2][10] = {"4Wire", "3Wire"};
     const static char StrEnabled[] = "Enabled";
     const static char StrExitMenu[] = "MENU";
-    const static char StrNotSet[] = "Not Set";
     extern const char StrRFIDReader[7][10];
     const static char StrWiFi[3][10] = {"Disabled", "Enabled", "SetupWifi"};
     const static char StrCapMode[][9] = {"Disabled", "Fixed", "Interval", "Flanders"};
@@ -1100,25 +1139,11 @@ const char * getMenuItemOption(uint8_t nav) {
             sprintf(Str, "%04u", value);
             return Str;
         case MENU_EVMETERHOST:
+            return getMeterHostStr(EVMeter, value);
         case MENU_MAINSMETERHOST:
-        case MENU_CIRCUITMETERHOST: {
-            Meter *meter = getMeterByHostnameMenu(nav);
-            if (meter == nullptr) {
-                return StrNotSet;
-            }
-            if (value == 0) {
-                if (strlen(meter->DeviceHostName) == 0) return StrNotSet;
-                compileServiceName(meter->Type, meter->DeviceHostName, Str, sizeof(Str));
-                if (Str[0] == '\0') return StrNotSet;
-                return Str;
-            }
-            const mDNSServiceEntry *service = getCompatiblemDNSServiceByIndex(meter->Type, value - 1);
-            if (service && !service->Name.isEmpty()) {
-                snprintf(Str, sizeof(Str), "%s", service->Name.c_str());
-                return Str;
-            }
-            return StrNotSet;
-        }
+            return getMeterHostStr(MainsMeter, value);
+        case MENU_CIRCUITMETERHOST:
+            return getMeterHostStr(CircuitMeter, value);
         case MENU_MAINSMETERADDRESS:
         case MENU_EVMETERADDRESS:
         case MENU_CIRCUITMETERADDRESS:
@@ -1343,21 +1368,25 @@ void GLCDMenu(uint8_t Buttons) {
                         value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
                         setItemValue(LCDNav, value);
                         break;
-                    case MENU_CIRCUITMETER:                                     // do not display the Sensorbox, HomeWizard P1/KWH or unused slots here
-                    case MENU_EVMETER:                                          // do not display the Sensorbox, HomeWizard P1/KWH or unused slots here
+                    case MENU_CIRCUITMETER:                                     // do not display the Sensorbox or unused slots here
+                    case MENU_EVMETER:                                          // do not display the Sensorbox or unused slots here
                         do {
                             value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
                         } while (value == EM_SENSORBOX);
                         setItemValue(LCDNav, value);
                         break;
                     case MENU_EVMETERHOST:
-                    case MENU_CIRCUITMETERHOST:
-                    case MENU_MAINSMETERHOST: {
-                        Meter *meter = getMeterByHostnameMenu(LCDNav);
-                        value = MenuNavInt(Buttons, value, 0, meter != nullptr ? getCompatiblemDNSServiceCount(meter->Type) : 0);
+                        value = MenuNavInt(Buttons, value, 0, getCompatiblemDNSServiceCount(EVMeter.Type));
                         setItemValue(LCDNav, value);
                         break;
-                    }
+                    case MENU_MAINSMETERHOST:
+                        value = MenuNavInt(Buttons, value, 0, getCompatiblemDNSServiceCount(MainsMeter.Type));
+                        setItemValue(LCDNav, value);
+                        break;
+                    case MENU_CIRCUITMETERHOST:
+                        value = MenuNavInt(Buttons, value, 0, getCompatiblemDNSServiceCount(CircuitMeter.Type));
+                        setItemValue(LCDNav, value);
+                        break;
                     case MENU_WIFI:
                         value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
                         setItemValue(LCDNav, value);
@@ -1423,8 +1452,14 @@ void GLCDMenu(uint8_t Buttons) {
     } else if (LCDNav > 1 && LCDNav != MENU_OFF && LCDNav != MENU_ON && Buttons == 0x5 && ButtonRelease == 0) {            // Button 2 pressed?
         ButtonRelease = 1;
         if (SubMenu) {                                                          // We are currently in Submenu
-            if (LCDNav == MENU_EVMETERHOST || LCDNav == MENU_MAINSMETERHOST || LCDNav == MENU_CIRCUITMETERHOST) {
-                commitMeterHostSelection(LCDNav);
+            if (LCDNav == MENU_EVMETERHOST){
+                commitMeterHostSelection(EVMeter, getItemValue(MENU_EVMETERHOST));
+            }
+            if (LCDNav == MENU_MAINSMETERHOST){
+                commitMeterHostSelection(MainsMeter, getItemValue(MENU_MAINSMETERHOST));
+            }
+            if (LCDNav == MENU_CIRCUITMETERHOST){
+                commitMeterHostSelection(CircuitMeter, getItemValue(MENU_CIRCUITMETERHOST));
             }
             SubMenu = 0;                                                        // Exit Submenu now
             digit = 3;

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -2540,7 +2540,7 @@ void ModbusRequestLoop() {
                 ModbusRequest++;
                 // fall through
             case 2:                                                         // Sensorbox or kWh meter that measures -all- currents
-                if (MainsMeter.Type && MainsMeter.Type != EM_API && MainsMeter.Type != EM_HOMEWIZARD_P1) { // we don't want modbus meter currents to conflict with EM_API and EM_HOMEWIZARD_P1 currents
+                if (MainsMeter.Type && MainsMeter.Type != EM_API && MainsMeter.Type != EM_HOMEWIZARD) { // we don't want modbus meter currents to conflict with EM_API and EM_HOMEWIZARD currents
                     _LOG_D("ModbusRequest %u: Request MainsMeter Measurement\n", ModbusRequest);
                     requestCurrentMeasurement(MainsMeter.Type, MainsMeter.Address);
                     break;
@@ -2570,7 +2570,7 @@ void ModbusRequestLoop() {
                 // fall through
             case 4:                                                         // EV kWh meter, Energy measurement (total charged kWh)
                 // Request Energy if EV meter is configured
-                if (Node[PollEVNode].EVMeter && Node[PollEVNode].EVMeter != EM_API) {
+                if (Node[PollEVNode].EVMeter && Node[PollEVNode].EVMeter != EM_API && Node[PollEVNode].EVMeter != EM_HOMEWIZARD) {
                     _LOG_D("ModbusRequest %u: Request Energy Node %u\n", ModbusRequest, PollEVNode);
                     requestEnergyMeasurement(Node[PollEVNode].EVMeter, Node[PollEVNode].EVAddress, 0);
                     break;
@@ -2579,7 +2579,7 @@ void ModbusRequestLoop() {
                 // fall through
             case 5:                                                         // EV kWh meter, Power measurement (momentary power in Watt)
                 // Request Power if EV meter is configured
-                if (Node[PollEVNode].EVMeter && Node[PollEVNode].EVMeter != EM_API) {
+                if (Node[PollEVNode].EVMeter && Node[PollEVNode].EVMeter != EM_API && Node[PollEVNode].EVMeter != EM_HOMEWIZARD) {
                     updated = 1;
                     switch(EVMeter.Type) {
                         //these meters all have their power measured via receiveCurrentMeasurement already
@@ -2654,7 +2654,7 @@ void ModbusRequestLoop() {
                 // fall through
             case 20:                                                         // EV kWh meter, Current measurement
                 // Request Current if EV meter is configured
-                if (Node[PollEVNode].EVMeter && Node[PollEVNode].EVMeter != EM_API) {
+                if (Node[PollEVNode].EVMeter && Node[PollEVNode].EVMeter != EM_API && Node[PollEVNode].EVMeter != EM_HOMEWIZARD) {
                     _LOG_D("ModbusRequest %u: Request EVMeter Current Measurement Node %u\n", ModbusRequest, PollEVNode);
                     requestCurrentMeasurement(Node[PollEVNode].EVMeter, Node[PollEVNode].EVAddress);
                     break;
@@ -2663,8 +2663,8 @@ void ModbusRequestLoop() {
                 // fall through
             case 21:
                 // Request active energy if Mainsmeter is configured
-                if ((MainsMeter.Type && MainsMeter.Type != EM_API && MainsMeter.Type != EM_HOMEWIZARD_P1 && MainsMeter.Type != EM_SENSORBOX ) || // EM_API, EM_HOMEWIZARD_P1 and Sensorbox do not support energy postings
-                    (MainsMeter.Type && MainsMeter.Type != EM_API && MainsMeter.Type != EM_HOMEWIZARD_P1 && MainsMeter.Type != EM_SENSORBOX )) {
+                if ((MainsMeter.Type && MainsMeter.Type != EM_API && MainsMeter.Type != EM_HOMEWIZARD && MainsMeter.Type != EM_SENSORBOX ))  // EM_API, EM_HOMEWIZARD and Sensorbox do not support energy postings
+                {
                     energytimer++; //this ticks approx every second?!?
                     if (energytimer == 30) {
                         _LOG_D("ModbusRequest %u: Request MainsMeter Import Active Energy Measurement\n", ModbusRequest);
@@ -2691,7 +2691,7 @@ void ModbusRequestLoop() {
                 ModbusRequest++;
                 // fall through
             case 22:                                                         // Sensorbox or kWh meter that measures -all- currents
-                if (CircuitMeter.Type && CircuitMeter.Type != EM_API && CircuitMeter.Type != EM_HOMEWIZARD_P1) { // we don't want modbus meter currents to conflict with EM_API and EM_HOMEWIZARD_P1 currents
+                if (CircuitMeter.Type && CircuitMeter.Type != EM_API && CircuitMeter.Type != EM_HOMEWIZARD) { // we don't want modbus meter currents to conflict with EM_API and EM_HOMEWIZARD currents
                     _LOG_D("ModbusRequest %u: Request CircuitMeter Current Measurement\n", ModbusRequest);
                     requestCurrentMeasurement(CircuitMeter.Type, CircuitMeter.Address);
                     break;
@@ -2700,7 +2700,7 @@ void ModbusRequestLoop() {
                 // fall through
 // CircuitMeter only reports currents right now, since that is its main function!
 /*            case 23:                                                         // Circuit kWh meter, Power measurement (momentary power in Watt)
-                if (CircuitMeter.Type && CircuitMeter.Type != EM_API && CircuitMeter.Type != EM_HOMEWIZARD_P1) { // we don't want modbus meter currents to conflict with EM_API and EM_HOMEWIZARD_P1 currents
+                if (CircuitMeter.Type && CircuitMeter.Type != EM_API && CircuitMeter.Type != EM_HOMEWIZARD) { // we don't want modbus meter currents to conflict with EM_API and EM_HOMEWIZARD currents
                     updated = 1;
                     switch(CircuitMeter.Type) {
                         //these meters all have their power measured via receiveCurrentMeasurement already
@@ -3465,6 +3465,9 @@ void Timer1S(void * parameter) {
 }
 #endif //SMARTEVSE_VERSION
 
+static int8_t getMeterHostMenuSlot(uint8_t nav);
+extern uint8_t MeterHostMenuSelection[3];
+
 
 /**
  * Check minimum and maximum of a value and set the variable
@@ -3591,7 +3594,16 @@ uint8_t setItemValue(uint8_t nav, uint16_t val) {
         case STATUS_ACCESS:
             setAccess((AccessStatus_t) val);
             break;
-
+        case MENU_EVMETERHOST:
+        case MENU_MAINSMETERHOST:
+        case MENU_CIRCUITMETERHOST: {
+            const int8_t slot = getMeterHostMenuSlot(nav);
+            if (slot < 0) {
+                return 0;
+            }
+            MeterHostMenuSelection[slot] = (uint8_t) val;
+            break;
+        }
         default:
             return 0;
     }
@@ -3655,6 +3667,15 @@ uint16_t getItemValue(uint8_t nav) {
             return EVMeter.Type;
         case MENU_EVMETERADDRESS:
             return EVMeter.Address;
+        case MENU_EVMETERHOST:
+        case MENU_MAINSMETERHOST:
+        case MENU_CIRCUITMETERHOST: {
+            const int8_t slot = getMeterHostMenuSlot(nav);
+            if (slot < 0) {
+                return 0;
+            }
+            return MeterHostMenuSelection[slot];
+        }
         case MENU_CIRCUITMETER:
             return CircuitMeter.Type;
         case MENU_CIRCUITMETERADDRESS:
@@ -3724,6 +3745,59 @@ uint16_t getItemValue(uint8_t nav) {
         default:
             return 0;
     }
+}
+
+Meter *getMeterByHostnameMenu(uint8_t nav) {
+    switch (nav) {
+        case MENU_EVMETERHOST:
+            return &EVMeter;
+        case MENU_MAINSMETERHOST:
+            return &MainsMeter;
+        case MENU_CIRCUITMETERHOST:
+            return &CircuitMeter;
+        default:
+            return nullptr;
+    }
+}
+
+static int8_t getMeterHostMenuSlot(uint8_t nav) {
+    switch (nav) {
+        case MENU_EVMETERHOST:
+            return 0;
+        case MENU_MAINSMETERHOST:
+            return 1;
+        case MENU_CIRCUITMETERHOST:
+            return 2;
+        default:
+            return -1;
+    }
+}
+
+uint8_t MeterHostMenuSelection[3] = {0, 0, 0};
+
+void resetMeterHostSelections(void) {
+    MeterHostMenuSelection[0] = 0;
+    MeterHostMenuSelection[1] = 0;
+    MeterHostMenuSelection[2] = 0;
+}
+
+void commitMeterHostSelection(uint8_t nav) {
+    Meter *meter = getMeterByHostnameMenu(nav);
+    const int8_t slot = getMeterHostMenuSlot(nav);
+    if (meter == nullptr || slot < 0) {
+        return;
+    }
+
+    const uint8_t value = MeterHostMenuSelection[slot];
+    if (value >= 1) {
+        const mDNSServiceEntry *service = getCompatiblemDNSServiceByIndex(meter->Type, value - 1);
+        if (service && !service->HostName.isEmpty()) {
+            strncpy(meter->DeviceHostName, service->HostName.c_str(), sizeof(meter->DeviceHostName));
+            meter->DeviceHostName[sizeof(meter->DeviceHostName) - 1] = '\0';
+        }
+    }
+
+    resetMeterHostSelections();
 }
 
 /**

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -3468,10 +3468,6 @@ void Timer1S(void * parameter) {
 }
 #endif //SMARTEVSE_VERSION
 
-static int8_t getMeterHostMenuSlot(uint8_t nav);
-extern uint8_t MeterHostMenuSelection[3];
-
-
 /**
  * Check minimum and maximum of a value and set the variable
  *
@@ -3598,15 +3594,14 @@ uint8_t setItemValue(uint8_t nav, uint16_t val) {
             setAccess((AccessStatus_t) val);
             break;
         case MENU_EVMETERHOST:
-        case MENU_MAINSMETERHOST:
-        case MENU_CIRCUITMETERHOST: {
-            const int8_t slot = getMeterHostMenuSlot(nav);
-            if (slot < 0) {
-                return 0;
-            }
-            MeterHostMenuSelection[slot] = (uint8_t) val;
+            EVMeter.HostMenuSelection = (uint8_t) val;
             break;
-        }
+        case MENU_MAINSMETERHOST:
+            MainsMeter.HostMenuSelection = (uint8_t) val;
+            break;
+        case MENU_CIRCUITMETERHOST:
+            CircuitMeter.HostMenuSelection = (uint8_t) val;
+            break;
         default:
             return 0;
     }
@@ -3671,14 +3666,11 @@ uint16_t getItemValue(uint8_t nav) {
         case MENU_EVMETERADDRESS:
             return EVMeter.Address;
         case MENU_EVMETERHOST:
+            return EVMeter.HostMenuSelection;
         case MENU_MAINSMETERHOST:
-        case MENU_CIRCUITMETERHOST: {
-            const int8_t slot = getMeterHostMenuSlot(nav);
-            if (slot < 0) {
-                return 0;
-            }
-            return MeterHostMenuSelection[slot];
-        }
+            return MainsMeter.HostMenuSelection;
+        case MENU_CIRCUITMETERHOST:
+            return CircuitMeter.HostMenuSelection;
         case MENU_CIRCUITMETER:
             return CircuitMeter.Type;
         case MENU_CIRCUITMETERADDRESS:
@@ -3748,59 +3740,6 @@ uint16_t getItemValue(uint8_t nav) {
         default:
             return 0;
     }
-}
-
-Meter *getMeterByHostnameMenu(uint8_t nav) {
-    switch (nav) {
-        case MENU_EVMETERHOST:
-            return &EVMeter;
-        case MENU_MAINSMETERHOST:
-            return &MainsMeter;
-        case MENU_CIRCUITMETERHOST:
-            return &CircuitMeter;
-        default:
-            return nullptr;
-    }
-}
-
-static int8_t getMeterHostMenuSlot(uint8_t nav) {
-    switch (nav) {
-        case MENU_EVMETERHOST:
-            return 0;
-        case MENU_MAINSMETERHOST:
-            return 1;
-        case MENU_CIRCUITMETERHOST:
-            return 2;
-        default:
-            return -1;
-    }
-}
-
-uint8_t MeterHostMenuSelection[3] = {0, 0, 0};
-
-void resetMeterHostSelections(void) {
-    MeterHostMenuSelection[0] = 0;
-    MeterHostMenuSelection[1] = 0;
-    MeterHostMenuSelection[2] = 0;
-}
-
-void commitMeterHostSelection(uint8_t nav) {
-    Meter *meter = getMeterByHostnameMenu(nav);
-    const int8_t slot = getMeterHostMenuSlot(nav);
-    if (meter == nullptr || slot < 0) {
-        return;
-    }
-
-    const uint8_t value = MeterHostMenuSelection[slot];
-    if (value >= 1) {
-        const mDNSServiceEntry *service = getCompatiblemDNSServiceByIndex(meter->Type, value - 1);
-        if (service && !service->HostName.isEmpty()) {
-            strncpy(meter->DeviceHostName, service->HostName.c_str(), sizeof(meter->DeviceHostName));
-            meter->DeviceHostName[sizeof(meter->DeviceHostName) - 1] = '\0';
-        }
-    }
-
-    resetMeterHostSelections();
 }
 
 /**

--- a/SmartEVSE-3/src/main.h
+++ b/SmartEVSE-3/src/main.h
@@ -258,48 +258,51 @@ void setPilot(bool On);
 #define MENU_RFIDREADER 9                                                       // 0x0107: Use RFID reader
 #define MENU_EVMETER 10                                                         // 0x0108: Type of EV electric meter
 #define MENU_EVMETERADDRESS 11                                                  // 0x0109: Address of EV electric meter
+#define MENU_EVMETERHOST 12 
 
 // System configuration (same on all SmartEVSE in a LoadBalancing setup)
-#define MENU_MODE 12                                                            // 0x0200: EVSE mode
-#define MENU_CIRCUIT 13                                                         // 0x0201: EVSE Circuit max Current
-#define MENU_GRID 14                                                            // 0x0202: Grid type to which the Sensorbox is connected
-#define MENU_SB2_WIFI 15                                                        // 0x0203: WiFi mode of the Sensorbox 2
-#define MENU_MAINS 16                                                           // 0x0204: Max Mains Current
-#define MENU_START 17                                                           // 0x0205: Surplus energy start Current
-#define MENU_STOP 18                                                            // 0x0206: Stop solar charging at 6A after this time
-#define MENU_IMPORT 19                                                          // 0x0207: Allow grid power when solar charging
-#define MENU_MAINSMETER 20                                                      // 0x0208: Type of Mains electric meter
-#define MENU_MAINSMETERADDRESS 21                                               // 0x0209: Address of Mains electric meter
-#define MENU_CIRCUITMETER 22
-#define MENU_CIRCUITMETERADDRESS 23
-#define MENU_EMCUSTOM_ENDIANESS 24                                              // 0x020D: Byte order of custom electric meter
-#define MENU_EMCUSTOM_DATATYPE 25                                               // 0x020E: Data type of custom electric meter
-#define MENU_EMCUSTOM_FUNCTION 26                                               // 0x020F: Modbus Function (3/4) of custom electric meter
-#define MENU_EMCUSTOM_UREGISTER 27                                              // 0x0210: Register for Voltage (V) of custom electric meter
-#define MENU_EMCUSTOM_UDIVISOR 28                                               // 0x0211: Divisor for Voltage (V) of custom electric meter (10^x)
-#define MENU_EMCUSTOM_IREGISTER 29                                              // 0x0212: Register for Current (A) of custom electric meter
-#define MENU_EMCUSTOM_IDIVISOR 30                                               // 0x0213: Divisor for Current (A) of custom electric meter (10^x)
-#define MENU_EMCUSTOM_PREGISTER 31                                              // 0x0214: Register for Power (W) of custom electric meter
-#define MENU_EMCUSTOM_PDIVISOR 32                                               // 0x0215: Divisor for Power (W) of custom electric meter (10^x)
-#define MENU_EMCUSTOM_EREGISTER 33                                              // 0x0216: Register for Energy (kWh) of custom electric meter
-#define MENU_EMCUSTOM_EDIVISOR 34                                               // 0x0217: Divisor for Energy (kWh) of custom electric meter (10^x)
-#define MENU_EMCUSTOM_READMAX 35                                                // 0x0218: Maximum register read (ToDo)
-#define MENU_WIFI 36                                                            // 0x0219: WiFi mode
-#define MENU_AUTOUPDATE 37
-#define MENU_C2 38
-#define MENU_MAX_TEMP 39
-#define MENU_CAPACITY_MODE 40
-#define MENU_SUMMAINS 41
-#define MENU_SUMMAINSTIME 42
-#define MENU_LCDPIN 43
-#define MENU_PAIRING 44
-#define MENU_APPSERVER 45
-#define MENU_LEDMODE 46
-#define MENU_OFF 47                                                             // so access bit is reset and charging stops when pressing < button 2 seconds
-#define MENU_ON 48                                                              // so access bit is set and charging starts when pressing > button 2 seconds
-#define MENU_EXIT 49
+#define MENU_MODE 13                                                            // 0x0200: EVSE mode
+#define MENU_CIRCUIT 14                                                         // 0x0201: EVSE Circuit max Current
+#define MENU_GRID 15                                                            // 0x0202: Grid type to which the Sensorbox is connected
+#define MENU_SB2_WIFI 16                                                        // 0x0203: WiFi mode of the Sensorbox 2
+#define MENU_MAINS 17                                                           // 0x0204: Max Mains Current
+#define MENU_START 18                                                           // 0x0205: Surplus energy start Current
+#define MENU_STOP 19                                                            // 0x0206: Stop solar charging at 6A after this time
+#define MENU_IMPORT 20                                                          // 0x0207: Allow grid power when solar charging
+#define MENU_MAINSMETER 21                                                      // 0x0208: Type of Mains electric meter
+#define MENU_MAINSMETERADDRESS 22                                               // 0x0209: Address of Mains electric meter
+#define MENU_MAINSMETERHOST 23 
+#define MENU_CIRCUITMETER 24
+#define MENU_CIRCUITMETERADDRESS 25
+#define MENU_CIRCUITMETERHOST 26
+#define MENU_EMCUSTOM_ENDIANESS 27                                              // 0x020D: Byte order of custom electric meter
+#define MENU_EMCUSTOM_DATATYPE 28                                               // 0x020E: Data type of custom electric meter
+#define MENU_EMCUSTOM_FUNCTION 29                                               // 0x020F: Modbus Function (3/4) of custom electric meter
+#define MENU_EMCUSTOM_UREGISTER 30                                              // 0x0210: Register for Voltage (V) of custom electric meter
+#define MENU_EMCUSTOM_UDIVISOR 31                                               // 0x0211: Divisor for Voltage (V) of custom electric meter (10^x)
+#define MENU_EMCUSTOM_IREGISTER 32                                              // 0x0212: Register for Current (A) of custom electric meter
+#define MENU_EMCUSTOM_IDIVISOR 33                                               // 0x0213: Divisor for Current (A) of custom electric meter (10^x)
+#define MENU_EMCUSTOM_PREGISTER 34                                              // 0x0214: Register for Power (W) of custom electric meter
+#define MENU_EMCUSTOM_PDIVISOR 35                                               // 0x0215: Divisor for Power (W) of custom electric meter (10^x)
+#define MENU_EMCUSTOM_EREGISTER 36                                              // 0x0216: Register for Energy (kWh) of custom electric meter
+#define MENU_EMCUSTOM_EDIVISOR 37                                               // 0x0217: Divisor for Energy (kWh) of custom electric meter (10^x)
+#define MENU_EMCUSTOM_READMAX 38                                                // 0x0218: Maximum register read (ToDo)
+#define MENU_WIFI 39                                                            // 0x0219: WiFi mode
+#define MENU_AUTOUPDATE 40
+#define MENU_C2 41
+#define MENU_MAX_TEMP 42
+#define MENU_CAPACITY_MODE 43
+#define MENU_SUMMAINS 44
+#define MENU_SUMMAINSTIME 45
+#define MENU_LCDPIN 46
+#define MENU_PAIRING 47
+#define MENU_APPSERVER 48
+#define MENU_LEDMODE 49
+#define MENU_OFF 50                                                             // so access bit is reset and charging stops when pressing < button 2 seconds
+#define MENU_ON 51                                                              // so access bit is set and charging starts when pressing > button 2 seconds
+#define MENU_EXIT 52
 
-#define MENU_STATE 50
+#define MENU_STATE 53
 
 class Button {
   public:

--- a/SmartEVSE-3/src/main.h
+++ b/SmartEVSE-3/src/main.h
@@ -271,7 +271,7 @@ void setPilot(bool On);
 #define MENU_IMPORT 20                                                          // 0x0207: Allow grid power when solar charging
 #define MENU_MAINSMETER 21                                                      // 0x0208: Type of Mains electric meter
 #define MENU_MAINSMETERADDRESS 22                                               // 0x0209: Address of Mains electric meter
-#define MENU_MAINSMETERHOST 23 
+#define MENU_MAINSMETERHOST 23
 #define MENU_CIRCUITMETER 24
 #define MENU_CIRCUITMETERADDRESS 25
 #define MENU_CIRCUITMETERHOST 26

--- a/SmartEVSE-3/src/meter.cpp
+++ b/SmartEVSE-3/src/meter.cpp
@@ -30,14 +30,14 @@ struct EMstruct EMConfig[] = {
     {"ABB",       ENDIANESS_HBF_HWF, 3, MB_DATATYPE_INT32,   0x5B00, 1, 0x5B0C, 2, 0x5B14, 2, 0x5000, 2,0x5004, 2}, // ABB B23 212-100 (0.1V / 0.01A / 0.01W / 0.01kWh) RS485 wiring reversed / max read count 125
     {"SolarEdge", ENDIANESS_HBF_HWF, 3, MB_DATATYPE_INT16,    40196, 0,  40191, 0,  40206, 0,  40234, 3, 40226, 3}, // SolarEdge SunSpec (0.01V (16bit) / 0.1A (16bit) / 1W  (16bit) / 1 Wh (32bit))
     {"WAGO",      ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x5002, 0, 0x500C, 0, 0x5012,-3, 0x600C, 0,0x6018, 0}, // WAGO 879-30x0 (V / A / kW / kWh)//TODO maar WAGO heeft ook totaal
-    {"API",       ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x5002, 0, 0x500C, 0, 0x5012, 3, 0x6000, 0,0x6018, 0}, // WAGO 879-30x0 (V / A / kW / kWh)
+    {"API",       ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x5002, 0, 0x500C, 0, 0x5012, 3, 0x6000, 0,0x6018, 0}, // API
     {"Eastron1P", ENDIANESS_HBF_HWF, 4, MB_DATATYPE_FLOAT32,    0x0, 0,    0x6, 0,   0x0C, 0,  0x48 , 0,0x4A  , 0}, // Eastron SDM630 (V / A / W / kWh) max read count 80
     {"Finder 7M", ENDIANESS_HBF_HWF, 4, MB_DATATYPE_FLOAT32,   2500, 0,   2516, 0,   2536, 0,   2638, 3,     0, 0}, // Finder 7M.38.8.400.0212 (V / A / W / Wh) / Backlight 10173
     {"Sinotimer", ENDIANESS_HBF_HWF, 4, MB_DATATYPE_INT16,      0x0, 1,    0x3, 2,    0x8, 0, 0x0027, 2,0x0031, 2}, // Sinotimer DTS6619 (0.1V (16bit) / 0.01A (16bit) / 1W  (16bit) / 1 Wh (32bit))
-    {"HmWzrd P1", ENDIANESS_HBF_HWF, 0, MB_DATATYPE_INT16,        0, 0,      0, 0,      0, 0,      0, 0,     0, 0}, // Homewizard P1 - network connected
+    {"Homewizrd", ENDIANESS_HBF_HWF, 0, MB_DATATYPE_INT16,        0, 0,      0, 0,      0, 0,      0, 0,     0, 0}, // Homewizard network connected meters
 
     {"Schneider", ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x0BD3, 0, 0x0BB7, 0, 0x0BF3,-3, 0xB02B, 0,0xB02D, 0}, // Schneider iEM3x5x series (V / A / kW / kWh) iEM3x50 counts only Energy Import, no Export
-    {"Chint 3P",     ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x2000, 1, 0x200C, 3, 0x2012, 1, 0x101E, 0,0x1028, 0}, // Chint DTSU666 (0.1V / mA / 0.1W / kWh)
+    {"Chint 3P",  ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x2000, 1, 0x200C, 3, 0x2012, 1, 0x101E, 0,0x1028, 0}, // Chint DTSU666 (0.1V / mA / 0.1W / kWh)
     {"C.Gavazzi", ENDIANESS_HBF_LWF, 4, MB_DATATYPE_INT32,      0x0, 1,    0xC, 3,   0x28, 1,   0x34, 1,  0x4E, 1}, // Carlo Gavazzi EM340 (0.1V / mA / 0.1W / 0.1kWh) 
     {"Chint 1P",  ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x2000, 1, 0x2002, 0, 0x2004,-3, 0x4000, 0,0x400A, 0}, // Chint DDSU666 (0.1V / A / kW / kWh)
     {"Unused 4",  ENDIANESS_LBF_LWF, 4, MB_DATATYPE_INT32,        0, 0,      0, 0,      0, 0,      0, 0,     0, 0}, // unused slot for future new meters
@@ -54,6 +54,7 @@ Meter::Meter(uint8_t type, uint8_t address, uint8_t timeout) {
         Irms[x] = 0;
         Power[x] = 0;
     }
+    DeviceHostName[0] = '\0';
     Type = type;
     Address = address;
     Imeasured = 0;

--- a/SmartEVSE-3/src/meter.cpp
+++ b/SmartEVSE-3/src/meter.cpp
@@ -55,6 +55,7 @@ Meter::Meter(uint8_t type, uint8_t address, uint8_t timeout) {
         Power[x] = 0;
     }
     DeviceHostName[0] = '\0';
+    HostMenuSelection = 0;
     Type = type;
     Address = address;
     Imeasured = 0;

--- a/SmartEVSE-3/src/meter.h
+++ b/SmartEVSE-3/src/meter.h
@@ -84,6 +84,7 @@ class Meter {
     uint8_t Type;                                                               // previously: MainsMeter; Type of Mains electric meter (0: Disabled / Constants EM_*)
     uint8_t Address;
     char DeviceHostName[32];                                                    // Selected hostname for networked meters
+        uint8_t HostMenuSelection;                                                  // Pending host menu selection for this meter
     int16_t Irms[3];                                                            // Momentary current per Phase (23 = 2.3A) (resolution 100mA)
     int16_t Imeasured;                                                          // Max of all Phases (Amps *10) of mains power
     int16_t Power[3];
@@ -126,6 +127,5 @@ class Meter {
 extern Meter MainsMeter;
 extern Meter EVMeter;                                                         // Type of EV electric meter (0: Disabled / Constants EM_*)
 extern Meter CircuitMeter;
-extern Meter *getMeterByHostnameMenu(uint8_t nav);
 
 #endif

--- a/SmartEVSE-3/src/meter.h
+++ b/SmartEVSE-3/src/meter.h
@@ -44,7 +44,7 @@
 #define EM_EASTRON1P 10
 #define EM_FINDER_7M 11
 #define EM_SINOTIMER 12
-#define EM_HOMEWIZARD_P1 13
+#define EM_HOMEWIZARD 13
 #define EM_SCHNEIDER 14
 #define EM_CHINT_3P 15
 #define EM_CARLO_CAVAZZI 16
@@ -83,6 +83,7 @@ class Meter {
   public:
     uint8_t Type;                                                               // previously: MainsMeter; Type of Mains electric meter (0: Disabled / Constants EM_*)
     uint8_t Address;
+    char DeviceHostName[32];                                                    // Selected hostname for networked meters
     int16_t Irms[3];                                                            // Momentary current per Phase (23 = 2.3A) (resolution 100mA)
     int16_t Imeasured;                                                          // Max of all Phases (Amps *10) of mains power
     int16_t Power[3];
@@ -125,5 +126,6 @@ class Meter {
 extern Meter MainsMeter;
 extern Meter EVMeter;                                                         // Type of EV electric meter (0: Disabled / Constants EM_*)
 extern Meter CircuitMeter;
+extern Meter *getMeterByHostnameMenu(uint8_t nav);
 
 #endif

--- a/SmartEVSE-3/src/modbus.cpp
+++ b/SmartEVSE-3/src/modbus.cpp
@@ -488,7 +488,7 @@ void requestMeasurement(uint8_t Meter, uint8_t Address, uint16_t Register, uint8
 void requestCurrentMeasurement(uint8_t Meter, uint8_t Address) {
     switch(Meter) {
         case EM_API:
-        case EM_HOMEWIZARD_P1:
+        case EM_HOMEWIZARD:
             break;
         case EM_SENSORBOX:
             if (SB2.SoftwareVer >= 1) {
@@ -742,7 +742,7 @@ void HandleModbusResponse(void) {
                 MainsMeter.ResponseToMeasurement(MB);
             } else if (CircuitMeter.Type && MB.Address == CircuitMeter.Address) {
                 CircuitMeter.ResponseToMeasurement(MB);
-            } else if (EVMeter.Type && MB.Address == EVMeter.Address) {
+            } else if (EVMeter.Type && EVMeter.Type != EM_HOMEWIZARD && MB.Address == EVMeter.Address) {
                 EVMeter.ResponseToMeasurement(MB);
             } else if (LoadBl == 1 && MB.Address > 1 && MB.Address <= NR_EVSES) {
                 // Packet from a Node EVSE, only for Master!
@@ -872,7 +872,7 @@ void ConfigureModbusMode(uint8_t newmode) {
             // Also add handler for all broadcast messages from Master.
             MBserver.registerWorker(BROADCAST_ADR, ANY_FUNCTION_CODE, &MBbroadcast);
 
-            if (EVMeter.Type && EVMeter.Type != EM_API) MBserver.registerWorker(EVMeter.Address, ANY_FUNCTION_CODE, &MBEVMeterResponse);
+            if (EVMeter.Type && EVMeter.Type != EM_API && EVMeter.Type != EM_HOMEWIZARD) MBserver.registerWorker(EVMeter.Address, ANY_FUNCTION_CODE, &MBEVMeterResponse);
             if (CircuitMeter.Type && CircuitMeter.Type != EM_API) MBserver.registerWorker(CircuitMeter.Address, ANY_FUNCTION_CODE, &MBCircuitMeterResponse);
 
             // Start ModbusRTU Node background task

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -1,6 +1,7 @@
 #if defined(ESP32)
 
 #include <WiFi.h>
+#include <algorithm>
 #include <vector>
 #include "mbedtls/md_internal.h"
 #include "mbedtls/base64.h"
@@ -897,91 +898,289 @@ void setTimeZone(void * parameter) {
 }
 
 #ifndef SENSORBOX_VERSION
-String homeWizardHost;
+std::array<mDNSServiceEntry, 8> mDNSServices = {};
 HTTPClient* homeWizardHttpClient=nullptr;
 bool homeWizardHttpClientInitialized = false;
 static bool mdnsDiscoveryInProgress = false;            // True when async mDNS task is running
 static unsigned long lastMdnsQueryTime = 0;             // Last time mDNS query was attempted
 static const unsigned long MDNS_RETRY_INTERVAL = 30000; // Retry mDNS discovery every 30 seconds if not found
 
+struct MdnsServiceQuery {
+    const char *service;
+    const char *protocol;
+};
+
+static constexpr MdnsServiceQuery mdnsServiceQueries[] = {
+    {"hwenergy", "tcp"}, //HomeWizard Energy Meters
+     // Add more service queries here for other brands/types if needed
+};
+
+/**
+ * @brief Add one discovered HomeWizard service to the cached mDNS table.
+ */
+static bool appendDiscoveredService(const String &hostname, uint16_t port, const String &ip, uint8_t &serviceCount) {
+    if (serviceCount >= mDNSServices.size()) {
+        return false;
+    }
+
+    const String fullHostname = hostname + ".local" + (port != 80 ? ":" + String(port) : "");
+    char serviceName[16];
+    mDNSServices[serviceCount].ServiceType = getmDNSServiceType(hostname);
+    mDNSServices[serviceCount].HostName = fullHostname;
+    compileServiceName(mDNSServices[serviceCount].ServiceType, mDNSServices[serviceCount].HostName.c_str(), serviceName, sizeof(serviceName));
+    mDNSServices[serviceCount].Name = serviceName;
+    serviceCount++;
+    return true;
+}
+
+/**
+ * @brief Clear the cached mDNS discovery table.
+ */
+static void clearmDNSServices() {
+    for (auto &service : mDNSServices) {
+        service.ServiceType = 0;
+        service.Name = "";
+        service.HostName = "";
+    }
+}
+
+/**
+ * @brief Count cached services matching a specific HomeWizard service type.
+ */
+uint8_t getmDNSServiceCount(int type) {
+    uint8_t count = 0;
+    for (const auto &service : mDNSServices) {
+        if (!service.HostName.isEmpty() && service.ServiceType == type) {
+            count++;
+        }
+    }
+    return count;
+}
+/**
+ * @brief Count all cached mDNS services.
+ */
+uint8_t getmDNSServiceCount() {
+    uint8_t count = 0;
+    for (const auto &service : mDNSServices) {
+        if (!service.HostName.isEmpty()) {
+            count++;
+        }
+    }
+    return count;
+}
+
+/**
+ * @brief Return a cached service by type, optional hostname pattern, and zero-based index.
+ */
+const mDNSServiceEntry *getmDNSServiceByIndex(int type, const String &hostnamePattern, uint8_t index, bool strict) {
+    uint8_t currentIndex = 0;
+    for (const auto &service : mDNSServices) {
+        const bool patternMatches = hostnamePattern.isEmpty() || service.HostName.indexOf(hostnamePattern) >= 0;
+        if (service.ServiceType != 0 &&
+            (type == 0 || service.ServiceType == type) &&
+            (!strict || patternMatches)) {
+            if (currentIndex == index) {
+                return &service;
+            }
+            currentIndex++;
+        }
+    }
+    return nullptr;
+}
+
+/**
+ * @brief Build a short display name for a discovered hostname.
+ */
+void compileServiceName(int type, const char *hostname, char *output, size_t outputSize) {
+    if (output == nullptr || outputSize == 0) {
+        return;
+    }
+
+    output[0] = '\0';
+    if (hostname == nullptr || hostname[0] == '\0') {
+        return;
+    }
+
+    switch (type) {
+        case EM_HOMEWIZARD: {
+            const char *end = strrchr(hostname, '.');
+            if (end == nullptr || end <= hostname) {
+                end = hostname + strlen(hostname);
+            }
+            const char *start = (size_t)(end - hostname) <= 6 ? hostname : end - 6;
+            const size_t length = (size_t)(end - start);
+            if (length >= outputSize) {
+                memcpy(output, start, outputSize - 1);
+                output[outputSize - 1] = '\0';
+            } else {
+                memcpy(output, start, length);
+                output[length] = '\0';
+            }
+            return;
+        }
+        default:
+            strlcpy(output, "Unknown", outputSize);
+            return;
+    }
+}
+
+/**
+ * @brief Map a discovered hostname to the corresponding meter service type.
+ */
+int getmDNSServiceType(const String &hostname) {
+    struct ServiceTypeMap {
+        const char *prefix;
+        const int type;
+    };
+    static const ServiceTypeMap serviceTypes[] = {
+        {"p1meter-", EM_HOMEWIZARD},
+        {"kwhmeter-", EM_HOMEWIZARD},
+         // Add more mappings for other brands/types here if needed
+    };
+
+    for (const auto &entry : serviceTypes) {
+        if (hostname.startsWith(entry.prefix)) {
+            return entry.type;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Count cached services compatible with the selected meter type.
+ */
+uint8_t getCompatiblemDNSServiceCount(uint8_t meterType) {
+    if (meterType == 0) {
+        return 0;
+    }
+
+    uint8_t count = 0;
+    for (const auto &service : mDNSServices) {
+        if (!service.HostName.isEmpty() && service.ServiceType == meterType) {
+            count++;
+        }
+    }
+    return count;
+}
+
+/**
+ * @brief Return the zero-based compatible service for a meter type.
+ */
+const mDNSServiceEntry *getCompatiblemDNSServiceByIndex(uint8_t meterType, uint8_t index) {
+    if (meterType == 0) {
+        return nullptr;
+    }
+
+    uint8_t currentIndex = 0;
+    for (const auto &service : mDNSServices) {
+        if (!service.HostName.isEmpty() && service.ServiceType == meterType) {
+            if (currentIndex == index) {
+                return &service;
+            }
+            currentIndex++;
+        }
+    }
+    return nullptr;
+}
+
+
 /**
  * @brief FreeRTOS task that performs mDNS discovery in the background.
  * 
  * This task runs the blocking mDNS query without blocking the main loop.
- * When complete, it updates homeWizardHost and deletes itself.
+ * When complete, it updates homeWizardP1Host and deletes itself.
  */
 void mdnsDiscoveryTask(void* parameter) {
     _LOG_A("mDNS discovery task started\n");
-    
-    // Search for _hwenergy._tcp services.
-    // https://api-documentation.homewizard.com/docs/discovery/
-    const int n = MDNS.queryService("hwenergy", "tcp");
-    if (n < 0) {
-        _LOG_A("discoverHWP1(): MDNS query failed.\n");
-    } else if (n == 0) {
-        _LOG_A("discoverHWP1(): No MDNS services found.\n");
-    } else {
-        for (int i = 0; i < n; i++) {
-            String hostname = MDNS.hostname(i);
-            if (hostname.startsWith("p1meter-")) {
-                const uint16_t port = MDNS.port(i);
-                _LOG_A("discoverHWP1(): Found HWP1 service: %s.local (%s:%d)\n", hostname.c_str(),
-                       MDNS.IP(i).toString().c_str(), port);
 
-                // Cache the result
-                homeWizardHost = hostname + ".local" + (port != 80 ? ":" + String(port) : "");
-                break;
-            }
+    bool serviceListReset = false;
+    uint8_t serviceCount = 0;
+    bool anyServicesFound = false;
+
+    struct DiscoveredService {
+        String hostname;
+        uint16_t port;
+        String ip;
+    };
+
+    for (const auto &query : mdnsServiceQueries) {
+        // Search for services defined in the compile-time query list.
+        // https://api-documentation.homewizard.com/docs/discovery/
+        const int n = MDNS.queryService(query.service, query.protocol);
+        if (n < 0) {
+            _LOG_A("discoverMeters(): MDNS query failed for %s.%s.\n", query.service, query.protocol);
+            continue;
         }
-        if (homeWizardHost.isEmpty()) {
-            _LOG_A("discoverHWP1(): No matching HWP1 service found.\n");
+        if (n == 0) {
+            _LOG_A("discoverMeters(): No MDNS services found for %s.%s.\n", query.service, query.protocol);
+            continue;
+        }
+
+        std::vector<DiscoveredService> services;
+        services.reserve(n);
+        for (int i = 0; i < n; i++) {
+            services.push_back({MDNS.hostname(i), MDNS.port(i), MDNS.IP(i).toString()});
+        }
+
+        std::sort(services.begin(), services.end(), [](const DiscoveredService &left, const DiscoveredService &right) {
+            return left.hostname < right.hostname;
+        });
+
+        if (!serviceListReset) {
+            clearmDNSServices();
+            serviceCount = 0;
+            serviceListReset = true;
+        }
+
+        for (const auto &service : services) {
+            _LOG_A("Discovered mDNS service: %s.local (%s:%d)\n", service.hostname.c_str(), service.ip.c_str(), service.port);
+            anyServicesFound = true;
+            appendDiscoveredService(service.hostname, service.port, service.ip, serviceCount);
         }
     }
-    
+
+    if (!anyServicesFound) {
+        _LOG_A("discoverMeters(): No matching mDNS services found.\n");
+    }
+
     mdnsDiscoveryInProgress = false;
     _LOG_A("mDNS discovery task completed\n");
     vTaskDelete(NULL);
 }
 
 /**
- * @brief Starts async mDNS discovery for HomeWizard P1 meter.
+ * @brief Starts async mDNS discovery for networked meters.
  *
  * This function uses mDNS to search for services advertising "_hwenergy._tcp" on the local network.
  * This function spawns a background task to perform the blocking mDNS query,
- * so the main loop remains responsive. The result is cached in homeWizardHost.
+ * so the main loop remains responsive. The result is cached in homeWizardP1Host and homeWizardKwhHost.
  *
  * @return The cached hostname if available, empty string if discovery is pending or not found
  */
-String discoverHomeWizardP1() {
-
-    // If there's a cached result, return it immediately
-    if (!homeWizardHost.isEmpty()) {
-        _LOG_D("discoverHWP1(): Using cached host '%s'.\n", homeWizardHost.c_str());
-        return homeWizardHost;
-    }
-
+void discoverNetworkMeters() {
     // If discovery is already in progress, don't start another
     if (mdnsDiscoveryInProgress) {
-        _LOG_D("discoverHWP1(): Discovery already in progress.\n");
-        return "";
+        _LOG_D("discoverNetworkMeters(): Discovery already in progress.\n");
+        return;
     }
 
     // Rate limit discovery attempts
     unsigned long now = millis();
     if (lastMdnsQueryTime != 0 && (now - lastMdnsQueryTime) < MDNS_RETRY_INTERVAL) {
         // Still in cooldown period, skip mDNS query
-        return "";
+        return;
     }
     lastMdnsQueryTime = now;
     
     // Start async mDNS discovery task
     mdnsDiscoveryInProgress = true;
-    _LOG_A("discoverHWP1(): Starting async mDNS discovery (next retry in %lu seconds)...\n", MDNS_RETRY_INTERVAL / 1000);
+    _LOG_A("discoverNetworkMeters(): Starting async mDNS discovery (next retry in %lu seconds)...\n", MDNS_RETRY_INTERVAL / 1000);
     
     // Create task with 4KB stack, priority 1 (low), running on any core
     BaseType_t result = xTaskCreate(
         mdnsDiscoveryTask,      // Task function
-        "mDNS_HWP1",            // Task name
+        "mDNS_Disc",            // Task name
         4096,                   // Stack size (bytes)
         NULL,                   // Parameters
         1,                      // Priority (low)
@@ -989,33 +1188,33 @@ String discoverHomeWizardP1() {
     );
     
     if (result != pdPASS) {
-        _LOG_A("discoverHWP1(): Failed to create mDNS discovery task!\n");
+        _LOG_A("discoverNetworkMeters(): Failed to create mDNS discovery task!\n");
         mdnsDiscoveryInProgress = false;
     }
     
-    return "";
+    return;
 }
 
 /**
- * @brief Retrieves active current values from a HomeWizard P1 meter API.
+ * @brief Retrieves active current values from a HomeWizard V1 API.
  *
  * This function sends an HTTP GET request to the specified URL to fetch the active current data
  * in JSON format, parses the JSON response, and retrieves specific fields for current.
  *
  * @return A pair containing:
  *     - A int flag indicating: 0: failure, 1: single phase current, 3: 3 phase current
- *     - An array of 3 values representing the active current in deci-amps for L1, L2, and L3
+ *     - An array of 6 values representing the active current in deci-amps for L1, L2, L3, total, import, and export
  */
-std::pair<int8_t, std::array<std::int16_t, 3> > getMainsFromHomeWizardP1() {
-
-    _LOG_A("getMainsFromHWP1(): invocation\n");
-    const String hostname = discoverHomeWizardP1();
-    if (hostname == "") {
-        return {false, {0, 0, 0}};
+std::pair<int8_t, std::array<std::int32_t, 6> > getDataFromHomeWizard(const char *hostname) {
+    _LOG_A("getDataFromHomeWizard(): invocation\n");
+    if (hostname == nullptr || hostname[0] == '\0') {
+        _LOG_A("getDataFromHomeWizard(): No hostname provided.\n");
+        return {false, {0, 0, 0, 0, 0, 0}};
     }
+    char url[64];
+    snprintf(url, sizeof(url), "http://%s/api/v1/data", hostname);
 
-    const String url = "http://" + hostname + "/api/v1/data";
-    _LOG_A("getMainsFromHWP1(): connect to URL %s\n", url.c_str());
+    _LOG_A("getDataFromHomeWizard(): connect to URL %s\n", url);
 
 
     if (!homeWizardHttpClientInitialized) {
@@ -1031,34 +1230,30 @@ std::pair<int8_t, std::array<std::int16_t, 3> > getMainsFromHomeWizardP1() {
     // Handle HTTP errors or timeout.
     const int httpCode = homeWizardHttpClient->GET();
     if (httpCode != HTTP_CODE_OK) {
-        _LOG_A("getMainsFromHWP1(): Error on HTTP request (httpCode=%i), url=%s.\n", httpCode, url.c_str());
+        _LOG_A("getDataFromHomeWizard(): Error on HTTP request (httpCode=%i), url=%s.\n", httpCode, url);
         homeWizardHttpClient->end(); // Always cleanup
         delete homeWizardHttpClient;
         homeWizardHttpClient = nullptr;
         homeWizardHttpClientInitialized = false;
-        // Clear cached hostname on connection errors so we can rediscover
-        // (e.g., if the HomeWizard P1 got a new IP address)
         if (httpCode < 0) {
-            homeWizardHost = "";
-            lastMdnsQueryTime = 0;  // Allow immediate rediscovery
-            _LOG_A("getMainsFromHWP1(): Connection failed, clearing cache for rediscovery.\n");
+            lastMdnsQueryTime = 0; // Force immediate rediscovery on next attempt if the error was a connection failure
+            _LOG_A("getDataFromHomeWizard(): Connection failed, allowing immediate rediscovery.\n");
         }
-        return {false, {0, 0, 0}};
+        return {false, {0, 0, 0, 0, 0, 0}};
     }
 
     // Get the response stream
     WiFiClient *stream = homeWizardHttpClient->getStreamPtr();
 
-    const char* currentKeys[] = {"active_current_l1_a", "active_current_l2_a", "active_current_l3_a"};
-    const char* powerKeys[] = {"active_power_l1_w", "active_power_l2_w", "active_power_l3_w"};
+    const char* currentKeys[] = {"active_current_l1_a", "active_current_l2_a", "active_current_l3_a","active_current_a"};
+    const char* powerKeys[] = { "active_power_l1_w", "active_power_l2_w", "active_power_l3_w","active_power_w"};
+    const char* totalsKeys[] = {"total_power_import_kwh", "total_power_export_kwh"};
 
     // Create a filter to parse only specific fields.
-    StaticJsonDocument<96> filter;
+    StaticJsonDocument<256> filter;
     for (const auto* key : currentKeys) filter[key] = true;
     for (const auto* key : powerKeys) filter[key] = true;
-
-    /////test homewizard connected to single phase mainsmeter
-    //const char stream[] = "{\"wifi_ssid\":\"Imaginous\",\"wifi_strength\":86,\"smr_version\":50,\"meter_model\":\"Kaifa AIFA-METER\",\"unique_id\":\"0000000000000000000000000000000000\",\"active_tariff\":1,\"total_power_import_kwh\":7412.085,\"total_power_import_t1_kwh\":4283.482,\"total_power_import_t2_kwh\":3128.603,\"total_power_export_kwh\":6551.330,\"total_power_export_t1_kwh\":1930.678,\"total_power_export_t2_kwh\":4620.652,\"active_power_w\":-2725.000,\"active_power_l1_w\":-2725.000,\"active_voltage_l1_v\":238.400,\"active_current_a\":11.430,\"active_current_l1_a\":-11.430,\"voltage_sag_l1_count\":8.000,\"voltage_swell_l1_count\":0.000,\"any_power_fail_count\":0.000,\"long_power_fail_count\":0.000,\"total_gas_m3\":1795.627,\"gas_timestamp\":250405135009,\"gas_unique_id\":\"0000000000000000000000000000000000\",\"external\":[{\"unique_id\":\"0000000000000000000000000000000000\",\"type\":\"gas_meter\",\"timestamp\":250405135009,\"value\":1795.627,\"unit\":\"m3\"}]}";
+    for (const auto* key : totalsKeys) filter[key] = true;
 
     // Create a filtered JSON document to hold the parsed data.
     DynamicJsonDocument doc(256);
@@ -1067,8 +1262,8 @@ std::pair<int8_t, std::array<std::int16_t, 3> > getMainsFromHomeWizardP1() {
 
     // Handle JSON parsing errors.
     if (error) {
-        _LOG_A("getMainsFromHomeWizardP1(): JSON deserialization failed: %s\n", error.c_str());
-        return {false, {0, 0, 0}};
+        _LOG_A("getDataFromHomeWizard(): JSON deserialization failed: %s\n", error.c_str());
+        return {false, {0, 0, 0, 0, 0, 0}};
     }
 
     uint8_t phases = 0;
@@ -1080,25 +1275,39 @@ std::pair<int8_t, std::array<std::int16_t, 3> > getMainsFromHomeWizardP1() {
 
     if (!phases) {
         // Early return on missing data.
-        _LOG_A("getMainsFromHomeWizardP1(): required JSON fields 'active_current_l1_a' not found\n");
-        return {phases, {0, 0, 0}};
+        _LOG_A("getDataFromHomeWizard(): required JSON fields 'active_current_a' not found\n");
+        return {phases, {0, 0, 0, 0, 0, 0}};
     }
 
+    std::array<int32_t, 6> evdata{};
     // Determine grid direction based on power: negative indicates feed-in, positive indicates usage.
     auto getCorrection = [&doc](const char* powerKey) -> int8_t {
         return doc[powerKey].as<int>() < 0 ? -1 : 1;
     };
 
-    // Process all three phases.
-    std::array<int16_t, 3> currents;
-    for (size_t i = 0; i < phases; ++i) {
-        int16_t rawCurrent = doc[currentKeys[i]].as<float>() * 10;
-        currents[i] = std::abs(rawCurrent) * getCorrection(powerKeys[i]);
+    if (phases == 1) {
+         _LOG_A("getDataFromHomeWizard(): reading single phase data\n");
+        // Single phase case: use 'active_current_a' and 'active_power_w' for correction
+        int16_t rawCurrent = doc[currentKeys[3]].as<float>() * 10;
+        int8_t correction = getCorrection(powerKeys[3]);
+        evdata[0] = std::abs(rawCurrent) * correction;
+        evdata[1] = 0;
+        evdata[2] = 0;
     }
-return {phases, currents};
+    else{
+        // Process all three phases.
+        for (size_t i = 0; i < 3; ++i) {
+            int16_t rawCurrent = doc[currentKeys[i]].as<float>() * 10;
+            evdata[i] = std::abs(rawCurrent) * getCorrection(powerKeys[i]);
+        }
+    }
+    evdata[3] = doc[totalsKeys[0]].as<float>() * 1000; // total import in Wh
+    evdata[4] = doc[totalsKeys[1]].as<float>() * 1000; // total export in Wh
+    evdata[5] = doc[powerKeys[3]].as<float>() * 1; // total power in Watts
+
+return {phases, evdata};
 }
 #endif
-
 
 void webServerRequest::setMessage(struct mg_http_message *hm) {
     hm_internal = hm;
@@ -1865,6 +2074,9 @@ static void startNetworkServices(void) {
 // Configure DNS, SNTP and mDNS when an interface gets an IP.
 // Can be called from both WiFi and Ethernet got-IP events.
 void onGotIP(const char *dns_ip) {
+    clearmDNSServices();
+    lastMdnsQueryTime = 0;
+
     // Load DHCP DNS into mongoose
     static char dns4url[] = "udp://123.123.123.123:53";
     if (dns_ip && strlen(dns_ip) > 0) {
@@ -2167,6 +2379,10 @@ void network_loop() {
     }
 
     mg_mgr_poll(&mgr, 100);                                                     // TODO increase this parameter to up to 1000 to make loop() less greedy
+
+    if (NetworkConnected() && getmDNSServiceCount() == 0) {
+        discoverNetworkMeters();
+    }
 
 #ifndef DEBUG_DISABLED
     // Remote debug over WiFi

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -1091,7 +1091,6 @@ const mDNSServiceEntry *getCompatiblemDNSServiceByIndex(uint8_t meterType, uint8
  * @brief FreeRTOS task that performs mDNS discovery in the background.
  * 
  * This task runs the blocking mDNS query without blocking the main loop.
- * When complete, it updates homeWizardP1Host and deletes itself.
  */
 void mdnsDiscoveryTask(void* parameter) {
     _LOG_A("mDNS discovery task started\n");
@@ -1156,9 +1155,8 @@ void mdnsDiscoveryTask(void* parameter) {
  *
  * This function uses mDNS to search for services advertising "_hwenergy._tcp" on the local network.
  * This function spawns a background task to perform the blocking mDNS query,
- * so the main loop remains responsive. The result is cached in homeWizardP1Host and homeWizardKwhHost.
+ * so the main loop remains responsive. 
  *
- * @return The cached hostname if available, empty string if discovery is pending or not found
  */
 void discoverNetworkMeters() {
     // If discovery is already in progress, don't start another
@@ -1282,13 +1280,14 @@ std::pair<int8_t, std::array<std::int32_t, 6> > getDataFromHomeWizard(const char
     }
 
     std::array<int32_t, 6> evdata{};
+    _LOG_A("Reading %u-phase data\n", phases);
+
     // Determine grid direction based on power: negative indicates feed-in, positive indicates usage.
     auto getCorrection = [&doc](const char* powerKey) -> int8_t {
         return doc[powerKey].as<int>() < 0 ? -1 : 1;
     };
 
     if (phases == 1) {
-         _LOG_A("Reading single phase data\n");
         // Single phase case: use 'active_current_a' and 'active_power_w' for correction
         int16_t rawCurrent = doc[currentKeys[3]].as<float>() * 10;
         int8_t correction = getCorrection(powerKeys[3]);

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -911,8 +911,10 @@ struct MdnsServiceQuery {
 };
 
 static constexpr MdnsServiceQuery mdnsServiceQueries[] = {
-    {"hwenergy", "tcp"}, //HomeWizard Energy Meters
-     // Add more service queries here for other brands/types if needed
+    {"hwenergy", "tcp"}, // HomeWizard Energy meters use this mDNS service
+    // Add more entries here when we support other meter brands or service types.
+    // Each brand can advertise a different mDNS service/protocol pair.
+    // For each entry, a separate mDNS discovery will be performed and cached in mDNSServices.
 };
 
 /**
@@ -924,11 +926,8 @@ static bool appendDiscoveredService(const String &hostname, uint16_t port, const
     }
 
     const String fullHostname = hostname + ".local" + (port != 80 ? ":" + String(port) : "");
-    char serviceName[16];
     mDNSServices[serviceCount].ServiceType = getmDNSServiceType(hostname);
     mDNSServices[serviceCount].HostName = fullHostname;
-    compileServiceName(mDNSServices[serviceCount].ServiceType, mDNSServices[serviceCount].HostName.c_str(), serviceName, sizeof(serviceName));
-    mDNSServices[serviceCount].Name = serviceName;
     serviceCount++;
     return true;
 }
@@ -939,7 +938,6 @@ static bool appendDiscoveredService(const String &hostname, uint16_t port, const
 static void clearmDNSServices() {
     for (auto &service : mDNSServices) {
         service.ServiceType = 0;
-        service.Name = "";
         service.HostName = "";
     }
 }
@@ -989,7 +987,10 @@ const mDNSServiceEntry *getmDNSServiceByIndex(int type, const String &hostnamePa
 }
 
 /**
- * @brief Build a short display name for a discovered hostname.
+ * @brief Build the compact name shown on the LCD for a discovered network meter.
+ *
+ * The helper trims the raw hostname into the shortest useful label that fits the LCD
+ * So the UI can show something readable instead of the full network name.
  */
 void compileServiceName(int type, const char *hostname, char *output, size_t outputSize) {
     if (output == nullptr || outputSize == 0) {
@@ -1001,6 +1002,8 @@ void compileServiceName(int type, const char *hostname, char *output, size_t out
         return;
     }
 
+    // Keep the formatting per meter type here so each service can define how its
+    // hostname should be shortened for the LCD without affecting the others.
     switch (type) {
         case EM_HOMEWIZARD: {
             const char *end = strrchr(hostname, '.');

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -1,7 +1,6 @@
 #if defined(ESP32)
 
 #include <WiFi.h>
-#include <algorithm>
 #include <vector>
 #include "mbedtls/md_internal.h"
 #include "mbedtls/base64.h"
@@ -1112,11 +1111,11 @@ void mdnsDiscoveryTask(void* parameter) {
         // https://api-documentation.homewizard.com/docs/discovery/
         const int n = MDNS.queryService(query.service, query.protocol);
         if (n < 0) {
-            _LOG_A("discoverMeters(): MDNS query failed for %s.%s.\n", query.service, query.protocol);
+            _LOG_A("MDNS query failed for %s.%s.\n", query.service, query.protocol);
             continue;
         }
         if (n == 0) {
-            _LOG_A("discoverMeters(): No MDNS services found for %s.%s.\n", query.service, query.protocol);
+            _LOG_A("No MDNS services found for %s.%s.\n", query.service, query.protocol);
             continue;
         }
 
@@ -1144,7 +1143,7 @@ void mdnsDiscoveryTask(void* parameter) {
     }
 
     if (!anyServicesFound) {
-        _LOG_A("discoverMeters(): No matching mDNS services found.\n");
+        _LOG_A("No matching mDNS services found.\n");
     }
 
     mdnsDiscoveryInProgress = false;
@@ -1164,7 +1163,7 @@ void mdnsDiscoveryTask(void* parameter) {
 void discoverNetworkMeters() {
     // If discovery is already in progress, don't start another
     if (mdnsDiscoveryInProgress) {
-        _LOG_D("discoverNetworkMeters(): Discovery already in progress.\n");
+        _LOG_D("Discovery already in progress.\n");
         return;
     }
 
@@ -1178,7 +1177,7 @@ void discoverNetworkMeters() {
     
     // Start async mDNS discovery task
     mdnsDiscoveryInProgress = true;
-    _LOG_A("discoverNetworkMeters(): Starting async mDNS discovery (next retry in %lu seconds)...\n", MDNS_RETRY_INTERVAL / 1000);
+    _LOG_A("Starting async mDNS discovery (next retry in %lu seconds)...\n", MDNS_RETRY_INTERVAL / 1000);
     
     // Create task with 4KB stack, priority 1 (low), running on any core
     BaseType_t result = xTaskCreate(
@@ -1191,7 +1190,7 @@ void discoverNetworkMeters() {
     );
     
     if (result != pdPASS) {
-        _LOG_A("discoverNetworkMeters(): Failed to create mDNS discovery task!\n");
+        _LOG_A("Failed to create mDNS discovery task!\n");
         mdnsDiscoveryInProgress = false;
     }
     
@@ -1209,15 +1208,15 @@ void discoverNetworkMeters() {
  *     - An array of 6 values representing the active current in deci-amps for L1, L2, L3, total, import, and export
  */
 std::pair<int8_t, std::array<std::int32_t, 6> > getDataFromHomeWizard(const char *hostname) {
-    _LOG_A("getDataFromHomeWizard(): invocation\n");
+    _LOG_A("Invocation\n");
     if (hostname == nullptr || hostname[0] == '\0') {
-        _LOG_A("getDataFromHomeWizard(): No hostname provided.\n");
+        _LOG_A("No hostname provided.\n");
         return {false, {0, 0, 0, 0, 0, 0}};
     }
     char url[64];
     snprintf(url, sizeof(url), "http://%s/api/v1/data", hostname);
 
-    _LOG_A("getDataFromHomeWizard(): connect to URL %s\n", url);
+    _LOG_A("Connect to URL %s\n", url);
 
 
     if (!homeWizardHttpClientInitialized) {
@@ -1233,14 +1232,14 @@ std::pair<int8_t, std::array<std::int32_t, 6> > getDataFromHomeWizard(const char
     // Handle HTTP errors or timeout.
     const int httpCode = homeWizardHttpClient->GET();
     if (httpCode != HTTP_CODE_OK) {
-        _LOG_A("getDataFromHomeWizard(): Error on HTTP request (httpCode=%i), url=%s.\n", httpCode, url);
+        _LOG_A("Error on HTTP request (httpCode=%i), url=%s.\n", httpCode, url);
         homeWizardHttpClient->end(); // Always cleanup
         delete homeWizardHttpClient;
         homeWizardHttpClient = nullptr;
         homeWizardHttpClientInitialized = false;
         if (httpCode < 0) {
             lastMdnsQueryTime = 0; // Force immediate rediscovery on next attempt if the error was a connection failure
-            _LOG_A("getDataFromHomeWizard(): Connection failed, allowing immediate rediscovery.\n");
+            _LOG_A("Connection failed, allowing immediate rediscovery.\n");
         }
         return {false, {0, 0, 0, 0, 0, 0}};
     }
@@ -1265,7 +1264,7 @@ std::pair<int8_t, std::array<std::int32_t, 6> > getDataFromHomeWizard(const char
 
     // Handle JSON parsing errors.
     if (error) {
-        _LOG_A("getDataFromHomeWizard(): JSON deserialization failed: %s\n", error.c_str());
+        _LOG_A("JSON deserialization failed: %s\n", error.c_str());
         return {false, {0, 0, 0, 0, 0, 0}};
     }
 
@@ -1278,7 +1277,7 @@ std::pair<int8_t, std::array<std::int32_t, 6> > getDataFromHomeWizard(const char
 
     if (!phases) {
         // Early return on missing data.
-        _LOG_A("getDataFromHomeWizard(): required JSON fields 'active_current_a' not found\n");
+        _LOG_A("Required JSON fields 'active_current_a' not found\n");
         return {phases, {0, 0, 0, 0, 0, 0}};
     }
 
@@ -1289,13 +1288,11 @@ std::pair<int8_t, std::array<std::int32_t, 6> > getDataFromHomeWizard(const char
     };
 
     if (phases == 1) {
-         _LOG_A("getDataFromHomeWizard(): reading single phase data\n");
+         _LOG_A("Reading single phase data\n");
         // Single phase case: use 'active_current_a' and 'active_power_w' for correction
         int16_t rawCurrent = doc[currentKeys[3]].as<float>() * 10;
         int8_t correction = getCorrection(powerKeys[3]);
         evdata[0] = std::abs(rawCurrent) * correction;
-        evdata[1] = 0;
-        evdata[2] = 0;
     }
     else{
         // Process all three phases.

--- a/SmartEVSE-3/src/network_common.h
+++ b/SmartEVSE-3/src/network_common.h
@@ -161,12 +161,12 @@ extern void onGotIP(const char *dns_ip);                                        
 #ifndef SENSORBOX_VERSION
 struct mDNSServiceEntry {
     int ServiceType;
-    String Name;
     String HostName;
 };
 
 extern std::pair<int8_t, std::array<std::int32_t, 6>> getDataFromHomeWizard(const char *hostname);
-extern std::array<mDNSServiceEntry, 8> mDNSServices;
+extern std::array<mDNSServiceEntry, 8> mDNSServices;                            // Allow discovery of up to 8 mDNS services for now
+                                                                                // if there is a use case for more we can always increase this
 #endif
 
 extern void discoverNetworkMeters();

--- a/SmartEVSE-3/src/network_common.h
+++ b/SmartEVSE-3/src/network_common.h
@@ -159,9 +159,25 @@ extern bool getLatestVersion(String owner_repo, String asset_name, char *version
 extern bool NetworkConnected(void);                                             // true if WiFi or Ethernet has IP
 extern void onGotIP(const char *dns_ip);                                        // shared IP-acquired handler
 #ifndef SENSORBOX_VERSION
-extern std::pair<int8_t, std::array<std::int16_t, 3>> getMainsFromHomeWizardP1();
-extern String homeWizardHost;
+struct mDNSServiceEntry {
+    int ServiceType;
+    String Name;
+    String HostName;
+};
+
+extern std::pair<int8_t, std::array<std::int32_t, 6>> getDataFromHomeWizard(const char *hostname);
+extern std::array<mDNSServiceEntry, 8> mDNSServices;
 #endif
+
+extern void discoverNetworkMeters();
+extern void compileServiceName(int type, const char *hostname, char *output, size_t outputSize);
+extern uint8_t getmDNSServiceCount(int type);
+extern uint8_t getmDNSServiceCount();
+extern uint8_t getCompatiblemDNSServiceCount(uint8_t meterType);
+extern const mDNSServiceEntry *getmDNSServiceByIndex(int type, uint8_t index);
+extern const mDNSServiceEntry *getmDNSServiceByIndex(int type, const String &hostnamePattern, uint8_t index, bool strict = false);
+extern const mDNSServiceEntry *getCompatiblemDNSServiceByIndex(uint8_t meterType, uint8_t index);
+extern int getmDNSServiceType(const String &hostname);
 
 #define FW_DOWNLOAD_PATH "http://smartevse-3.s3.eu-west-2.amazonaws.com"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,19 +44,23 @@ Only appears if [MODE](#mode) is **Smart** or **Solar**. Set the type of MAINS k
 - **Sensorbox**: The Sensorbox sends measurement data to the SmartEVSE.
 - **API**: MAINS meter data is fed through the [REST API](REST_API.md) or [MQTT API](#mqtt-api).
 - **Phoenix C** / **Finder** / **...** / **Custom**: A Modbus kWh meter is used.
-- **HmWzrd P1**: HomeWizard P1 meter (wifi based connection to the smart meter's P1 port).
+- **Homewizrd**: Mains meter data is polled from a network connected HomeWizard meter (P1 or kWh).
 
 **Note**:  
 - Eastron1P is for single-phase Eastron meters.  
 - Eastron3P is for Eastron three-phase meters.  
 - InvEastron is for Eastron three-phase meters fed from below (inverted).
 
-If MAINS MET is not **Disabled** and not **API**, these settings appear:
+If MAINS MET is not **Disabled** and not **API** and not **HomeWizrd**, these settings appear:
 
 - **MAINSADR**: Set the Modbus address for the kWh meter.
 - **GRID**: 3 or 4 wire (only appears when Sensorbox with CT’s is used).
   - **4Wire**: Star connection with 3 phase wires and neutral.
   - **3Wire**: Delta connection with 3 phase wires without neutral.
+
+If MAINS MET is **HomeWizrd**, this settings appears:
+
+- **MAINS HST**: Select a networked meter through a list of mDNS discovered hosts.
 
 ## CIRCT MET
 Set Type of kWh Meter (measures power and charged energy) of the circuit this SmartEVSE is on; only configure this when you are in "subpanel configuration", see [Installation](installation.md).
@@ -70,9 +74,13 @@ Set Type of kWh Meter (measures power and charged energy) of the circuit this Sm
 - Eastron3P is for Eastron three-phase meters.
 - InvEastron is for Eastron’s three-phase meter fed from below (inverted).
 
-If CIRCT MET is not **Disabled** and not **API**, this setting appears:
+If CIRCT MET is not **Disabled** and not **API** and not **Homewizrd**, this setting appears:
 
 - **CIRCT ADR**: Set the Modbus address for the Circuit Meter.
+
+If CIRCT MET is **HomeWizrd**, this setting appears:
+
+- **CIRCT HST**: Select a networked meter through a list of mDNS discovered hosts.
 
 ## EV METER
 Set Type of EV kWh Meter (measures power and charged energy)
@@ -80,15 +88,20 @@ Set Type of EV kWh Meter (measures power and charged energy)
 - **Disabled**: No EV meter connected.
 - **API**: EV meter data is fed through the REST API or MQTT API.
 - **Phoenix C** / **Finder** / **...** / **Custom**: A Modbus kWh meter is used.
+- **HomeWizrd**: A Networked Homewizard meter is used.
 
 **Note**:  
 - Eastron1P is for single-phase Eastron meters.  
 - Eastron3P is for Eastron three-phase meters.  
 - InvEastron is for Eastron’s three-phase meter fed from below (inverted).
 
-If EV METER is not **Disabled** and not **API**, this setting appears:
+If EV METER is not **Disabled** and not **API** and not **Homewizrd**, this setting appears:
 
 - **EV ADR**: Set the Modbus address for the EV Meter.
+
+If EV METER is **HomeWizrd**, this setting appears:
+
+- **EV HST**: Select a networked meter through a list of mDNS discovered hosts.
 
 ## MAINS
 Only appears when a [MAINS MET](#mains-met) is configured. Set max mains current (10-200A) per phase.


### PR DESCRIPTION
Add generic support for networked meters via mDNS discovery, laying the groundwork for future brands and meter types. 

Expand HomeWizard integration to support both P1 and kWh meters (P1 and P3). HomeWizard meters can now be used for Mains, Circuit, and EVMeter, with a new setting on each to select the meter by hostname.

<img width="288" height="416" alt="image" src="https://github.com/user-attachments/assets/35727f4f-93b0-41a0-ae76-fcc70771643f" />



