### PR TITLE
use a dedicated flash mode for ota firmware updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,15 @@ sdkconfig.*
 .DS_Store
 */.DS_Store
 .idea
+
+# Vue UI (feature branch) — leftover working-tree files when on master
+SmartEVSE-3/app/
+
+# Vue UI build outputs copied into data/ (generated, not tracked)
+SmartEVSE-3/data/app.html
+SmartEVSE-3/data/app-sw.js
+SmartEVSE-3/data/manifest.json
+SmartEVSE-3/data/pwa-192.png
+SmartEVSE-3/data/pwa-512.png
+SmartEVSE-3/data/apple-touch-icon.png
+

--- a/SmartEVSE-3/data/update2.html
+++ b/SmartEVSE-3/data/update2.html
@@ -55,12 +55,69 @@ var setStatus = function(text) {
               console.error('Error: ', err)
             })
         }
+
+        // ---- Dedicated flash (recovery) mode --------------------------------
+        function fmtBytes(n) {
+          if (n === undefined || n === null) return '?';
+          return n.toLocaleString() + ' (' + (n / 1024).toFixed(1) + ' KiB)';
+        }
+
+        function renderFlashInfo(d) {
+          var html = '';
+          if (d.flash_mode) {
+            html += '<div style="background:#ffe6b3;border:2px solid #e08020;border-radius:.5em;padding:1em;margin-bottom:1em">'
+                  + '<b>&#9889; FLASH MODE ACTIVE</b><br>'
+                  + 'Only WiFi and the update endpoint are running &mdash; the whole heap is reserved for flashing. '
+                  + 'Upload firmware below, or '
+                  + '<button onclick="exitFlashMode()">Exit flash mode (reboot normally)</button>'
+                  + '</div>';
+          } else {
+            var dis = d.vehicle_connected ? ' disabled' : '';
+            html += '<button onclick="enterFlashMode()"' + dis + '>Reboot in Flash Mode</button> ';
+            html += d.vehicle_connected
+                  ? '<span style="color:#b00000">(unavailable: a vehicle is connected &mdash; unplug the EV first)</span>'
+                  : '<span>(reboots into a minimal recovery mode for reliable flashing)</span>';
+          }
+          html += '<table style="text-align:left;margin-top:1em">';
+          html += '<tr><th colspan="2">Memory</th></tr>';
+          html += '<tr><td>Free heap</td><td>' + fmtBytes(d.heap_free) + '</td></tr>';
+          html += '<tr><td>Largest free block</td><td>' + fmtBytes(d.heap_max_block) + '</td></tr>';
+          html += '<tr><td>Min free heap (since boot)</td><td>' + fmtBytes(d.heap_min_free) + '</td></tr>';
+          html += '<tr><td>Total heap</td><td>' + fmtBytes(d.heap_total) + '</td></tr>';
+          html += '<tr><th colspan="2">Flash</th></tr>';
+          html += '<tr><td>Flash chip size</td><td>' + fmtBytes(d.flash_chip_size) + '</td></tr>';
+          html += '<tr><td>Sketch size (current)</td><td>' + fmtBytes(d.sketch_size) + '</td></tr>';
+          html += '<tr><td>Free sketch space</td><td>' + fmtBytes(d.free_sketch_space) + '</td></tr>';
+          html += '<tr><th colspan="2">OTA partitions</th></tr>';
+          if (d.running) html += '<tr><td>Running (' + d.running.label + ')</td><td>@0x' + d.running.address.toString(16) + ', ' + fmtBytes(d.running.size) + '</td></tr>';
+          if (d.target)  html += '<tr><td><b>Target &mdash; next flash writes here (' + d.target.label + ')</b></td><td>@0x' + d.target.address.toString(16) + ', ' + fmtBytes(d.target.size) + '</td></tr>';
+          html += '</table>';
+          document.getElementById('flashpanel').innerHTML = html;
+        }
+
+        function updateFlashInfo() {
+          fetch('/flashinfo').then(r => r.json()).then(renderFlashInfo).catch(e => console.error(e));
+        }
+
+        function enterFlashMode() {
+          if (!confirm('Reboot into flash mode?\n\nThe charger goes offline briefly and only this update page is available until you flash firmware or exit flash mode.')) return;
+          fetch('/flashmode').then(r => r.text()).then(t => setStatus(t)).catch(e => console.error(e));
+        }
+
+        function exitFlashMode() {
+          fetch('/reboot').then(r => r.text()).then(t => setStatus(t)).catch(e => console.error(e));
+        }
     </script>
   </head>
   <body onload="loadData()">
     <div id="container">
       <div id="info">
           Current version: <span id="version"></span><br>
+          =========================================================================================<br>
+          FLASH MODE &amp; DIAGNOSTICS
+          <br><br>
+          <div id="flashpanel">Loading diagnostics&hellip;</div>
+          <br>
           =========================================================================================<br>
           UPDATE FIRMWARE
           <br><br>
@@ -121,6 +178,8 @@ function loadData() {
     document.getElementById("version").innerHTML = sessionStorage.getItem("version");
     getLatestVersion(OWNER_FACT, REPO_FACT, 'latest_fact');
     getLatestVersion(OWNER_COMM, REPO_COMM, 'latest_comm');
+    updateFlashInfo();                  // flash-mode banner + heap/partition diagnostics
+    setInterval(updateFlashInfo, 2000);
 }
 
 async function getLatestVersion(owner, repo, element) {

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -3581,6 +3581,30 @@ extern void Timer20ms(void * parameter);
     // Read all settings from non volatile memory; MQTTprefix will be overwritten if stored in NVS
     read_settings();                                                            // initialize with default data when starting for the first time
     validate_settings();
+
+    // ---- Dedicated flash (recovery) mode ----------------------------------
+    // If the flash-mode flag was persisted in NVS (via the "Reboot in flash
+    // mode" button), bring up ONLY WiFi and the web/OTA endpoint and skip
+    // everything else: no RFID, no LittleFS/OCPP, no MQTT, no Modbus polling,
+    // no control timers, no LCD. Because none of those subsystems are started,
+    // there is nothing to tear down or leak and the heap is left pristine and
+    // contiguous, so the OTA buffer allocation that fails on a long-running
+    // device has the whole pool to draw from. The contactor stays open and the
+    // CP/pilot stays disconnected (set in the GPIO init above) — entry into
+    // this mode is gated on no vehicle being connected.
+    FlashMode = getFlashModeFlag();
+    if (FlashMode) {
+        _LOG_A("*** FLASH MODE: WiFi + OTA only, skipping RFID/LittleFS/OCPP/MQTT/Modbus/LCD/timers ***\n");
+#if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40
+        ledcWrite(RED_CHANNEL, 0);
+        ledcWrite(GREEN_CHANNEL, 0);
+        ledcWrite(BLUE_CHANNEL, 255);                                          // steady blue LED = flash mode
+#endif
+        WiFiSetup();                                                           // only WiFi + web/OTA endpoint
+        return;                                                                // do not start any tasks or charging logic
+    }
+    // -----------------------------------------------------------------------
+
     ReadRFIDlist();                                                             // Read all stored RFID's from storage
 
     // Note that LittleFS is also used by OCPP
@@ -3704,6 +3728,13 @@ extern void Timer20ms(void * parameter);
 #endif
 
     firmwareUpdateTimer = random(FW_UPDATE_DELAY, 0xffff);
+
+    // We reached the end of a normal boot: the running image is good. Confirm it
+    // so the bootloader cancels any pending rollback. This is the safety net for
+    // the flash-mode reboot path — if a freshly flashed image were bad and never
+    // got here, a rollback-enabled bootloader would auto-revert to the previous
+    // partition. Harmless (no-op) when bootloader rollback is not enabled.
+    esp_ota_mark_app_valid_cancel_rollback();
 }
 
 
@@ -3869,8 +3900,8 @@ static void homewizard_task(void *parameter) {
 void loop() {
 
     network_loop();
-    homewizard_loop();
-    
+    if (!FlashMode) homewizard_loop();          // no meter polling in flash mode
+
     static unsigned long lastCheck = 0;
     if (millis() - lastCheck >= 1000) {
         lastCheck = millis();
@@ -3968,15 +3999,18 @@ void loop() {
     }
 
     //OCPP lifecycle management
+    // Never start OCPP in flash mode — it must stay off to keep the heap pristine.
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
-    if (OcppMode && !getOcppContext() && NetworkConnected()) {
-        ocppInit();
-    } else if (!OcppMode && getOcppContext()) {
-        ocppDeinit();
-    }
+    if (!FlashMode) {
+        if (OcppMode && !getOcppContext() && NetworkConnected()) {
+            ocppInit();
+        } else if (!OcppMode && getOcppContext()) {
+            ocppDeinit();
+        }
 
-    if (OcppMode && getOcppContext()) {
-        ocppLoop();
+        if (OcppMode && getOcppContext()) {
+            ocppLoop();
+        }
     }
 #endif //ENABLE_OCPP
 

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -88,6 +88,38 @@ mg_connection *HttpListener80, *HttpListener443;
 
 bool shouldReboot = false;
 
+// Dedicated "flash mode" (recovery / safe-mode boot). When the flag below is
+// persisted in NVS and the device reboots, setup() brings up only WiFi and the
+// web/OTA endpoint and skips OCPP, MQTT, RFID, Modbus polling and the control
+// timers. Nothing else is started, so the heap stays pristine and contiguous
+// and the OTA buffer allocation cannot fail for lack of a large free block.
+bool FlashMode = false;
+
+// The flag lives in its own NVS namespace so it can be read/written
+// independently of the much larger "settings" blob, very early in boot.
+#define FLASHMODE_NVS_NAMESPACE "flashmode"
+#define FLASHMODE_NVS_KEY       "flag"
+
+// Read the persisted flash-mode flag. Safe to call before read_settings().
+bool getFlashModeFlag(void) {
+    bool flag = false;
+    if (preferences.begin(FLASHMODE_NVS_NAMESPACE, true)) {                  // true = readonly
+        flag = preferences.getBool(FLASHMODE_NVS_KEY, false);
+        preferences.end();
+    }
+    return flag;
+}
+
+// Persist (or clear) the flash-mode flag. Cleared after a successful flash, or
+// when the user reboots out of flash mode, so a normal reboot returns to normal.
+void setFlashModeFlag(bool flag) {
+    if (preferences.begin(FLASHMODE_NVS_NAMESPACE, false)) {
+        if (flag) preferences.putBool(FLASHMODE_NVS_KEY, true);
+        else      preferences.remove(FLASHMODE_NVS_KEY);
+        preferences.end();
+    }
+}
+
 extern void write_settings(void);
 extern void StopwebServer(void); //TODO or move over to network.cpp?
 extern void StartwebServer(void); //TODO or move over to network.cpp?
@@ -1833,6 +1865,7 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                     if (offset + hm->body.len >= size) {                                           //EOF
                         if(Update.end(true)) {
                             _LOG_A("\nUpdate Success\n");
+                            setFlashModeFlag(false);            // flash done: next boot is normal mode
                             delay(1000);
                             ESP.restart();
                         } else {
@@ -1884,6 +1917,7 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                                 _LOG_A("Signature is valid!\n");
                                 esp_ota_set_boot_partition( target_partition );
                                 _LOG_A("\nUpdate Success\n");
+                                setFlashModeFlag(false);        // flash done: next boot is normal mode
                                 shouldReboot = true;
                                 //ESP.restart(); does not finish the call to fn_http_server, so the last POST of apps.js gets no response....
                                 //which results in a "verify failed" message on the /update screen AFTER the reboot :-)
@@ -1951,6 +1985,9 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                 mg_http_reply(c, 200, "", "%ld", res);
             }
         } else if (mg_http_match_uri(hm, "/reboot")) {
+            // A normal reboot always returns to normal mode: clear the flash-mode
+            // flag so this doubles as the "exit flash mode" escape hatch.
+            setFlashModeFlag(false);
             shouldReboot = true;
 #ifndef SMARTEVSE_VERSION //sensorbox
             mg_http_reply(c, 200, "", "Rebooting after 5s...");
@@ -1958,9 +1995,53 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
             if (State == STATE_C) {
                 mg_http_reply(c, 202, "", "Reboot scheduled: Device will reboot 5 seconds after the EV stops charging...");
             } else {
-                mg_http_reply(c, 200, "", "Device will reboot in 5 seconds...");
+                mg_http_reply(c, 200, "", FlashMode ? "Leaving flash mode, rebooting in 5 seconds..." : "Device will reboot in 5 seconds...");
             }
 #endif
+        } else if (mg_http_match_uri(hm, "/flashmode")) {
+            // Request a reboot into the dedicated flash (recovery) mode.
+            // Gated on no vehicle being connected (STATE_A) — never tear the
+            // device down or reboot in the middle of a charging session.
+#ifdef SMARTEVSE_VERSION
+            if (State != STATE_A) {
+                mg_http_reply(c, 409, "", "Cannot enter flash mode while a vehicle is connected. Unplug the EV first.");
+            } else {
+#endif
+                setFlashModeFlag(true);
+                shouldReboot = true;
+                mg_http_reply(c, 200, "", "Rebooting into flash mode in 5 seconds...");
+#ifdef SMARTEVSE_VERSION
+            }
+#endif
+        } else if (mg_http_match_uri(hm, "/flashinfo")) {
+            // Report heap/flash/partition diagnostics as JSON, polled by the
+            // update page so the user can see the pristine contiguous heap and
+            // which OTA partition the next flash will be written to.
+            const esp_partition_t* running = esp_ota_get_running_partition();
+            const esp_partition_t* target  = esp_ota_get_next_update_partition(NULL);
+            DynamicJsonDocument doc(512);
+            doc["flash_mode"]       = FlashMode;
+            doc["vehicle_connected"] = (State != STATE_A);
+            doc["heap_total"]       = ESP.getHeapSize();
+            doc["heap_free"]        = ESP.getFreeHeap();
+            doc["heap_min_free"]    = ESP.getMinFreeHeap();
+            doc["heap_max_block"]   = ESP.getMaxAllocHeap();             // largest contiguous block
+            doc["flash_chip_size"]  = ESP.getFlashChipSize();
+            doc["sketch_size"]      = ESP.getSketchSize();
+            doc["free_sketch_space"] = ESP.getFreeSketchSpace();
+            if (running) {
+                doc["running"]["label"]   = running->label;
+                doc["running"]["address"] = running->address;
+                doc["running"]["size"]    = running->size;
+            }
+            if (target) {
+                doc["target"]["label"]    = target->label;              // partition the next flash writes to
+                doc["target"]["address"]  = target->address;
+                doc["target"]["size"]     = target->size;
+            }
+            String json;
+            serializeJson(doc, json);
+            mg_http_reply(c, 200, "Content-Type: application/json\r\n", "%s\n", json.c_str());
         } else if (mg_http_match_uri(hm, "/settings") && !memcmp("POST", hm->method.buf, hm->method.len)) {
             DynamicJsonDocument doc(64);
 #if MQTT
@@ -2393,7 +2474,7 @@ void WiFiSetup(void) {
     handleWIFImode();                                                           //go into the mode that was saved in nonvolatile memory
 
 #if MQTT && MQTT_ESP
-    MQTTclient.connect();
+    if (!FlashMode) MQTTclient.connect();                                       // keep the heap pristine in flash mode
 #endif
 
 }

--- a/SmartEVSE-3/src/network_common.h
+++ b/SmartEVSE-3/src/network_common.h
@@ -145,6 +145,9 @@ public:
 };
 
 extern bool shouldReboot;
+extern bool FlashMode;                  // true when running in dedicated flash (recovery) mode
+extern bool getFlashModeFlag(void);     // read persisted flash-mode flag from NVS
+extern void setFlashModeFlag(bool flag);// persist/clear flash-mode flag in NVS
 extern void network_loop(void);
 extern String APhostname;
 extern webServerRequest* request;


### PR DESCRIPTION
This PR is still in draft mode - what do you think about something like this? I still need to test it, but what about the idea?

# Add a dedicated flash (recovery) mode for reliable OTA updates
### Problem
On devices that have been powered for weeks, OTA firmware uploads often crash. The cause is heap fragmentation: the ESP32 allocator never moves live allocations, so after long uptime there is no contiguous block large enough for the OTA buffer (and for the TLS buffers on the HTTPS path), even when total free heap looks fine. Disabling OCPP at runtime does not fix this, because freeing memory does not defragment the heap and does not release everything.

### Solution
A persistent NVS flag triggers a minimal safe-mode boot. When set, setup() brings up only WiFi and the web/OTA endpoint and skips RFID, LittleFS/OCPP, MQTT, Modbus polling, the control timers, and the LCD. Since those subsystems are never started, the heap stays pristine and contiguous, so the OTA allocation has the whole pool to draw from. This turns "hope enough contiguous heap is free" into a deterministic guarantee. After a successful flash the flag is cleared and the device reboots into normal mode.

### Charger safety
Entry is gated on no vehicle connected (State == STATE_A). The endpoint refuses while an EV is plugged in, matching the existing auto-update behaviour. The contactor stays open and the pilot stays disconnected.
Power-loss safety is preserved. Flashing still writes to the inactive partition and only flips the boot pointer at the very end.
esp_ota_mark_app_valid_cancel_rollback() is called at the end of a normal boot, so a bad image flashed via this mode auto-reverts if the bootloader is built with rollback enabled (no-op otherwise).
No new blocking loop. The upload stays chunked per HTTP request, so the watchdog is fed naturally.
### UI
The update page gains a "Reboot in Flash Mode" button (disabled when a vehicle is connected) and a diagnostics panel that polls /flashinfo and shows free heap, largest contiguous free block, min free heap, total heap, flash size, sketch size, free sketch space, and both OTA partitions with the next-flash target highlighted. In flash mode it shows a banner and an "Exit flash mode" button.

### Endpoints
/flashmode: set the flag and reboot, gated on State == STATE_A.
/flashinfo: JSON heap, flash, and partition diagnostics.
/reboot: now also clears the flag, so a normal reboot always leaves flash mode.
Notes


### Testing
Builds clean (flash 92.1%, RAM 22%). Not yet verified on hardware.