### PR TITLE
Add support for Smartstuff P1 meters

### DIFF
--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -1096,6 +1096,10 @@ int getmDNSServiceType(const String &hostname) {
     static const ServiceTypeMap serviceTypes[] = {
         {"p1meter-", EM_HOMEWIZARD},
         {"kwhmeter-", EM_HOMEWIZARD},
+        {"P1-", EM_HOMEWIZARD},
+        {"ETH-", EM_HOMEWIZARD},
+        {"NRG-", EM_HOMEWIZARD},
+        {"ULTRA-", EM_HOMEWIZARD},
          // Add more mappings for other brands/types here if needed
     };
 


### PR DESCRIPTION
The P1 meters sold by smart-stuff.nl have a feature that allows them to emulate HomeWizard P1 meters. See https://docs.smart-stuff.nl/dsmr-api/geavanceerd/api-overzicht#homewizard-compatible-api

I have added the hostname prefixes of all P1 meters sold by Smartstuff to the network_common.cpp file. As a result, they can now be discovered by the mDNS query of the SmartEVSE.

