### PR TITLE
Fix undefined mainsHost variable HomeWizard mains meters

### DIFF
--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -386,7 +386,7 @@
             } else {
               $('.with_mainsmeter').show();
               if ((data.mains_meter && data.mains_meter.host || '').trim()) {
-                $('#mainsmeter_host').text(mainsHost);
+                $('#mainsmeter_host').text(data.mains_meter.host);
                 $('[id=with_mainsmeter_host]').show();
               } else {
                 $('[id=with_mainsmeter_host]').hide();


### PR DESCRIPTION
fixes [#389](https://github.com/dingo35/SmartEVSE-3.5/issues/389)

Referencing the undeclared 'mainsHost' variable throws an uncaught ReferenceError whenever a HomeWizard mains meter reports a host field, which halts the loadData() polling loop entirely (including the setTimeout that re-triggers it) and the with_modem show/hide logic that runs after it. This leaves modem-related UI cards (e.g. EV State) permanently visible and freezes the WebUI after the first load.