### PR TITLE
Update index.html  - Widen Mains Meter card

### DIFF
--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+<head
 	<title>Smart EVSE V3</title>
 
   <link rel="stylesheet" href="https://code.jquery.com/mobile/1.4.5/jquery.mobile-1.4.5.min.css" />
@@ -1296,7 +1296,7 @@
                                 <div class="col mr-2">
                                     <div class="text-xl font-weight-bold text-info text-uppercase mb-1">Mains Phase Details</div>
                                     <div class="row no-gutters align-items-center">
-                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
+                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                           Total:
                                         </div>
                                         <div class="col">
@@ -1304,7 +1304,7 @@
                                         </div>
                                     </div>
                                     <div class="row no-gutters align-items-center">
-                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
+                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                           L1:
                                         </div>
                                         <div class="col">
@@ -1312,7 +1312,7 @@
                                         </div>
                                     </div>
                                     <div class="row no-gutters align-items-center">
-                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
+                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                           L2:
                                         </div>
                                         <div class="col">
@@ -1320,7 +1320,7 @@
                                         </div>
                                     </div>
                                     <div class="row no-gutters align-items-center">
-                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
+                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                           L3:
                                         </div>
                                         <div class="col">
@@ -1328,7 +1328,7 @@
                                         </div>
                                     </div>
                                     <div class="row no-gutters align-items-center" id="with_p1_api_data_date">
-                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
+                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                           Date:
                                         </div>
                                         <div class="col">
@@ -1336,7 +1336,7 @@
                                         </div>
                                     </div>
                                     <div class="row no-gutters align-items-center" id="with_p1_api_data_time">
-                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
+                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                           Time:
                                         </div>
                                         <div class="col">
@@ -1344,7 +1344,7 @@
                                         </div>
                                     </div>
                                     <div class="row no-gutters align-items-center" id="with_mainsmeter_host" style="display: none;">
-                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
+                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                           Hostname:
                                         </div>
                                         <div class="col">


### PR DESCRIPTION
Widen Mains Meter card label column to fix Hostname wrapping

The Mains Phase Details card's label column (Total/L1/L2/L3/Date/Time/
  Hostname) is fixed at width: 100px, while the equivalent EV Meter card
  uses 120px. 'Hostname:' is just wide enough to wrap inside 100px,
  dropping the colon onto its own line.

  The other, shorter labels sharing that column never hit the limit, so
  this went unnoticed until the Hostname row started rendering real
  text (see #389). 
  
  Widened all 7 rows in the card to 120px, matching
  the EV Meter card, so the value column stays aligned across every
  row.